### PR TITLE
Cloud Run wake proxy + VM auto-stop for ~$0 idle cost

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,29 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: photogroup-215600
+
+      - name: Ensure VM is running
+        run: |
+          STATUS=$(gcloud compute instances describe main \
+            --project photogroup-215600 --zone asia-east2-a \
+            --format='get(status)' 2>/dev/null || echo "UNKNOWN")
+          echo "VM status: $STATUS"
+          if [ "$STATUS" != "RUNNING" ]; then
+            echo "Starting VM for deployment..."
+            gcloud compute instances start main \
+              --project photogroup-215600 --zone asia-east2-a
+            # Wait until SSH-ready (boot can take a minute)
+            for i in $(seq 1 30); do
+              if gcloud compute ssh main --project photogroup-215600 --zone asia-east2-a \
+                --command "true" 2>/dev/null; then
+                echo "VM is reachable"
+                break
+              fi
+              echo "Waiting for VM... ($i)"
+              sleep 10
+            done
+          fi
+        timeout-minutes: 10
       
       - name: Deploy nginx configuration
         run: |
@@ -71,6 +94,20 @@ jobs:
           # Twilio credentials are passed as env vars to the container at runtime
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+
+      - name: Deploy wake proxy to Cloud Run
+        run: |
+          chmod +x deploy-wake-proxy.sh wake-proxy/vm-idle-stop/install-idle-stop.sh
+          # App deploy already ran; refresh Cloud Run image + idle-stop timer
+          ./deploy-wake-proxy.sh
+        timeout-minutes: 20
+        env:
+          ZONE: asia-east2-a
+          REGION: asia-east2
+          INSTANCE: main
+          PROJECT: photogroup-215600
+          IDLE_MINUTES: 60
+          WAKE_STOP_SECRET: ${{ secrets.WAKE_STOP_SECRET }}
       
       - name: Deployment summary
         run: |
@@ -78,5 +115,5 @@ jobs:
           echo "Instance: main"
           echo "Zone: asia-east2-a"
           echo "Project: photogroup-215600"
-          echo "Deployment method: Docker"
+          echo "Deployment method: Docker + Cloud Run wake proxy"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
             package-lock.json
             ui/package-lock.json
             server/package-lock.json
+            wake-proxy/package-lock.json
       
       - name: Install root dependencies
         run: npm ci
@@ -36,6 +37,11 @@ jobs:
       - name: Install server dependencies
         run: |
           cd server
+          npm ci
+
+      - name: Install wake-proxy dependencies
+        run: |
+          cd wake-proxy
           npm ci
       
       - name: Create secret file from GitHub Secrets
@@ -71,6 +77,11 @@ jobs:
         run: |
           cd server
           npm run test:integration
+
+      - name: Run wake-proxy unit tests
+        run: |
+          cd wake-proxy
+          npm test
       
       - name: Install Playwright browsers
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ P2P photo sharing web app. Users create rooms, drop photos, and share them direc
 - **WebTorrent for P2P** -- not a custom WebRTC solution; uses BitTorrent protocol over WebRTC
 - **SSE not WebSocket for updates** -- real-time room updates use Server-Sent Events, not socket.io
 - **Vite, not CRA** -- migrated from create-react-app to Vite
+- **Wake proxy + auto-stop** -- public DNS hits Cloud Run (`wake-proxy/`); GCE VM starts on demand and idle-stops; ephemeral IP (no static IP) for ~$0 idle cost in `asia-east2`
 
 ## Entry Points
 
@@ -21,6 +22,7 @@ P2P photo sharing web app. Users create rooms, drop photos, and share them direc
 | Server start | `server/app.js` | Creates Express app, initializes all services, listens on :8081 |
 | UI start | `ui/src/index.js` | React 19 createRoot, renders `<App />` |
 | Build config | `ui/vite.config.js` | Dev server :3000, proxies /api to :8081, Node.js polyfills |
+| Wake proxy | `wake-proxy/src/index.js` | Cloud Run ingress: start VM, cold-start page, HTTP/WS proxy |
 | Tests (all) | `package.json` → `test` script | Runs `test-all.js` which parallelizes server + UI tests |
 | CI/CD | `.github/workflows/test.yml` + `deploy.yml` | Test on push, deploy on success |
 
@@ -38,6 +40,18 @@ app.js
       ├── ServerPeer      -- server-side WebTorrent client (one per room)
       └── Topology        -- analyzes connection types (direct/relay/NAT)
 ```
+
+### Production ingress (wake proxy)
+
+```
+Cloud Run photogroup-wake (wake-proxy/)
+  → GCE start/stop + HTTPS proxy
+  → VM nginx (:443) → Docker photogroup-app (:8081/:9000)
+                     → Docker hackersbot (:18080)
+VM timer photogroup-idle-stop → stop instance after nginx idle
+```
+
+Deploy: `./deploy-wake-proxy.sh` then point DNS at Cloud Run; release static IP with `./release-static-ip.sh`. See `DEPLOYMENT.md`.
 
 ### API Pattern
 
@@ -106,6 +120,7 @@ No Redux/Zustand -- state lives in `RoomsService.js` which is a plain class mana
 
 - Twilio credentials: `server/secret/index.js` (gitignored) or env vars
 - In CI: GitHub Secrets → written to `server/secret/index.js` during workflow
+- Optional `WAKE_STOP_SECRET` GitHub Secret → enables Cloud Run `/__wake__/stop` for Scheduler backups
 - No `.env` files used -- secrets are either in the secret module or env vars
 
 ## Gotchas
@@ -115,6 +130,8 @@ No Redux/Zustand -- state lives in `RoomsService.js` which is a plain class mana
 - The WebSocket tracker port (9000) must be accessible alongside the HTTP port (8081)
 - Node.js polyfills in `ui/src/compatibility/` and `ui/vite.config.js` are required because WebTorrent uses Node.js APIs
 - `wrtc` npm package (native WebRTC for Node.js) can be tricky to install on some platforms
+- Production DNS should target Cloud Run (`photogroup-wake`), not the VM IP; the VM uses an ephemeral IP that changes on each start
+- CI deploy starts the VM if it was idle-stopped before pushing nginx/Docker updates
 
 ## Cursor Cloud specific instructions
 
@@ -129,11 +146,17 @@ This project requires Node.js >= 24.0.0. The VM update script handles installing
 ### Running tests
 - Server tests (98 tests, Mocha): `cd server && npm test`
 - UI unit tests (72 tests, Vitest): `cd ui && npm test -- --run`
+- Wake proxy unit tests: `cd wake-proxy && npm test`
 - E2E tests (Playwright): `cd ui && npm run test:e2e` — auto-starts both servers via `playwright.config.js`
 - All tests: `node test-all.js` (note: `test-all.js` uses CommonJS `require()`, not ES modules)
 
 ### No external services required
 No database, Redis, or Docker needed for development. All state is in-memory. Twilio credentials are optional (only needed for TURN relay NAT traversal; app falls back to Google STUN servers without them).
+
+### Production wake / cost control
+- Deploy wake proxy: `./deploy-wake-proxy.sh`
+- Release static IP after DNS cutover: `./release-static-ip.sh`
+- Idle stop runs on the VM via `photogroup-idle-stop.timer` (default 60 minutes)
 
 ### Pushing changes
 Always push to `main`. Before pushing:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,6 +7,76 @@
 - **Additional service**: `hackernews.photogroup.network` (reverse-proxied to a Docker container on the same VM)
 - **Zone**: `asia-east2-a`
 - **Instance Name**: `main`
+- **Public ingress**: Cloud Run wake proxy (`photogroup-wake`) — DNS points here, not at the VM
+- **VM IP**: Ephemeral (released when the instance is stopped). Do **not** reserve a static IP unless you intentionally use the legacy DNS→VM setup.
+
+## Cost-saving architecture (wake proxy + auto-stop)
+
+Recommended production shape for low-traffic Asia hosting:
+
+```
+DNS (photogroup.network, www, hackernews)
+  → Cloud Run wake proxy (asia-east2, min instances 0)
+      → starts GCE e2-micro on demand
+      → HTTPS reverse-proxy to nginx on the VM
+VM systemd timer → stops the instance after ~60 minutes of nginx idle
+```
+
+| State | Approx. monthly cost |
+|-------|----------------------|
+| VM stopped (idle) | **~$0** (ephemeral IP gone; 20 GB disk within Always Free allowance) |
+| VM running | **~$0.01/hour** compute in `asia-east2` (~$8.56/mo if left on 24/7) |
+| Cloud Run (low traffic) | **~$0** (within free tier) |
+
+Cold start for the first visitor is typically **1–2 minutes** (GCE boot + Docker/nginx). Subsequent requests are fast until idle auto-stop.
+
+Public HTTPS is terminated at **Cloud Run** (domain mapping / Cloudflare). The wake proxy reaches the VM over **HTTP :80** with header `X-Wake-Proxy: 1` (see `server/config/photogroup.network`). VM Let's Encrypt certs remain optional for legacy direct HTTPS access; ACME HTTP-01 renewals will not work while DNS points at Cloud Run (use DNS-01 or drop VM certs).
+
+### Deploy / migrate to wake proxy
+
+1. Ensure the VM, nginx, Docker apps, and SSL on the VM still work (origin HTTPS).
+2. Deploy the wake proxy:
+   ```bash
+   ./deploy-wake-proxy.sh
+   ```
+3. Point DNS at Cloud Run (replace the old A record that targeted the VM):
+   ```bash
+   # If domain mappings are available in asia-east2:
+   gcloud beta run domain-mappings create --service photogroup-wake \
+     --domain photogroup.network --region asia-east2 --project photogroup-215600
+   # Repeat for www.photogroup.network and hackernews.photogroup.network
+   # Then add the DNS records printed by gcloud.
+   #
+   # Alternative: Cloudflare CNAME each hostname → <service>.run.app (proxy on).
+   ```
+4. Release the legacy static IP (~$3.65/mo savings when stopped):
+   ```bash
+   ./release-static-ip.sh
+   ```
+5. Verify:
+   ```bash
+   curl -sS https://photogroup.network/__wake__/status
+   # Open https://photogroup.network — expect starting page, then the app
+   ```
+
+### Wake proxy controls
+
+| Path | Notes |
+|------|-------|
+| `/__wake__/healthz` | Liveness — does **not** start the VM |
+| `/__wake__/status` | JSON boot state (used by the starting page) |
+| `/__wake__/stop` | POST + header `X-Wake-Stop-Secret` (optional Cloud Scheduler backup) |
+
+Idle auto-stop is installed on the VM by `deploy-wake-proxy.sh` (`photogroup-idle-stop.timer`, every 10 minutes, default idle threshold 60 minutes). Override with `IDLE_MINUTES=45 ./deploy-wake-proxy.sh`.
+
+The VM service account and the wake Cloud Run service account both need permission to start/stop the instance (`roles/compute.instanceAdmin.v1`). `deploy-wake-proxy.sh` grants these.
+
+### New VM without a static IP
+
+```bash
+./create-vm.sh                 # ephemeral IP (default)
+USE_STATIC_IP=1 ./create-vm.sh # legacy DNS→VM only
+```
 
 ## Prerequisites
 
@@ -44,7 +114,9 @@ gcloud compute instances create main \
 
 ### Step 2: Configure DNS
 
-After the VM is created, you need to point your domain to the VM's static IP address.
+**Preferred (wake proxy):** Point DNS at the Cloud Run wake service after `./deploy-wake-proxy.sh` — see [Cost-saving architecture](#cost-saving-architecture-wake-proxy--auto-stop). Do **not** point the apex A record at the VM.
+
+**Legacy (DNS → VM):** After the VM is created, point your domain at the VM's external IP address.
 
 1. **Get the VM's external IP address**:
    ```bash
@@ -230,7 +302,9 @@ gcloud compute ssh main --project photogroup-215600 --zone asia-east2-a --comman
 
 ## Deployment Scripts
 
-- **create-vm.sh**: Creates VM instance with firewall rules and static IP (first-time setup)
+- **create-vm.sh**: Creates VM instance with firewall rules (ephemeral IP by default; `USE_STATIC_IP=1` for legacy)
+- **deploy-wake-proxy.sh**: Deploys Cloud Run wake proxy + installs VM idle-stop timer
+- **release-static-ip.sh**: Detaches and deletes the reserved regional static IP after DNS moves to Cloud Run
 - **deploy-all.sh**: Runs all deployment steps in sequence
 - **deploy-copy.sh**: Copies UI build and server files to `./bin/` directory
 - **deploy-app.sh**: Uploads application files to VM and restarts with PM2

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ graph TB
     end
 
     subgraph Infra["Infrastructure"]
+        CR[Cloud Run wake proxy]
         NG[nginx - Reverse Proxy]
         LE[Let's Encrypt SSL]
-        GCP[GCP VM - e2-micro]
+        GCP[GCP VM - e2-micro + idle-stop]
         GH[GitHub Actions CI/CD]
     end
 
@@ -91,10 +92,12 @@ graph TB
     RM --> SP
     RM --> PE
     SP --> TP
+    CR -->|start + proxy| NG
     NG --> SS
     LE --> NG
     GCP --> NG
     GH -->|deploy| GCP
+    GH -->|deploy| CR
 ```
 
 ### API Endpoints

--- a/create-vm.sh
+++ b/create-vm.sh
@@ -10,6 +10,9 @@ MACHINE_TYPE=e2-micro
 IMAGE_FAMILY=ubuntu-2204-lts
 IMAGE_PROJECT=ubuntu-os-cloud
 DISK_SIZE=20GB
+# Wake-proxy architecture uses an ephemeral IP (released when the VM is stopped).
+# Set USE_STATIC_IP=1 only for the legacy "DNS A record → VM" setup.
+USE_STATIC_IP="${USE_STATIC_IP:-0}"
 
 # Extract region from zone (asia-east2-a -> asia-east2)
 # Using bash parameter expansion: remove shortest match of -[a-z] from end
@@ -39,60 +42,69 @@ if gcloud compute instances describe $INSTANCE --project $PROJECT --zone $ZONE 2
         exit 1
     fi
 else
-    # Create static IP address
-    echo "Creating static IP address..."
-    echo "Region: $REGION"
-    
-    # First, try to check if IP exists and get it
-    STATIC_IP=$(gcloud compute addresses describe $INSTANCE-ip --project $PROJECT --region $REGION --format="value(address)" 2>/dev/null | tr -d '\r\n ')
-    
-    if [ -n "$STATIC_IP" ]; then
-        echo "Static IP already exists."
-    else
-        echo "Creating new static IP address..."
-        CREATE_IP_OUTPUT=$(gcloud compute addresses create $INSTANCE-ip \
-            --project $PROJECT \
-            --region $REGION \
-            --description "Static IP for PhotoGroup VM" 2>&1)
-        CREATE_IP_EXIT=$?
-        echo "$CREATE_IP_OUTPUT" | filter_python_warnings
+    ADDRESS_ARGS=()
+    if [ "$USE_STATIC_IP" = "1" ]; then
+        # Create static IP address (legacy: DNS A record points at the VM)
+        echo "Creating static IP address..."
+        echo "Region: $REGION"
         
-        # Exit code 49 means "already exists" - treat as success
-        if [ $CREATE_IP_EXIT -ne 0 ] && [ $CREATE_IP_EXIT -ne 49 ]; then
-            echo "ERROR: Failed to create static IP address (exit code: $CREATE_IP_EXIT)"
-            echo "Full output:"
+        # First, try to check if IP exists and get it
+        STATIC_IP=$(gcloud compute addresses describe $INSTANCE-ip --project $PROJECT --region $REGION --format="value(address)" 2>/dev/null | tr -d '\r\n ')
+        
+        if [ -n "$STATIC_IP" ]; then
+            echo "Static IP already exists."
+        else
+            echo "Creating new static IP address..."
+            CREATE_IP_OUTPUT=$(gcloud compute addresses create $INSTANCE-ip \
+                --project $PROJECT \
+                --region $REGION \
+                --description "Static IP for PhotoGroup VM" 2>&1)
+            CREATE_IP_EXIT=$?
             echo "$CREATE_IP_OUTPUT" | filter_python_warnings
+            
+            # Exit code 49 means "already exists" - treat as success
+            if [ $CREATE_IP_EXIT -ne 0 ] && [ $CREATE_IP_EXIT -ne 49 ]; then
+                echo "ERROR: Failed to create static IP address (exit code: $CREATE_IP_EXIT)"
+                echo "Full output:"
+                echo "$CREATE_IP_OUTPUT" | filter_python_warnings
+                exit 1
+            fi
+            
+            if [ $CREATE_IP_EXIT -eq 49 ]; then
+                echo "Static IP already exists (this is OK)."
+            else
+                echo "Static IP created."
+            fi
+            
+            # Now retrieve the IP address
+            STATIC_IP=$(gcloud compute addresses describe $INSTANCE-ip --project $PROJECT --region $REGION --format="value(address)" 2>/dev/null | tr -d '\r\n ')
+        fi
+        
+        # If still empty, try alternative method: list and filter
+        if [ -z "$STATIC_IP" ]; then
+            echo "WARNING: Could not retrieve IP with describe, trying list method..."
+            STATIC_IP=$(gcloud compute addresses list --project $PROJECT --filter="name=$INSTANCE-ip AND region:$REGION" --format="value(address)" 2>/dev/null | head -1 | tr -d '\r\n ')
+        fi
+        
+        # Final check - if still empty, show error and debug info
+        if [ -z "$STATIC_IP" ]; then
+            echo "ERROR: Failed to retrieve static IP address"
+            echo "Looking for IP named '$INSTANCE-ip' in region '$REGION'"
+            echo "Attempting to list all addresses to debug..."
+            gcloud compute addresses list --project $PROJECT --format="table(name,address,region)" 2>/dev/null || true
             exit 1
         fi
-        
-        if [ $CREATE_IP_EXIT -eq 49 ]; then
-            echo "Static IP already exists (this is OK)."
-        else
-            echo "Static IP created."
-        fi
-        
-        # Now retrieve the IP address
-        STATIC_IP=$(gcloud compute addresses describe $INSTANCE-ip --project $PROJECT --region $REGION --format="value(address)" 2>/dev/null | tr -d '\r\n ')
+        echo "Static IP address: $STATIC_IP"
+        echo ""
+        echo "IMPORTANT: Update your DNS A record for photogroup.network to point to: $STATIC_IP"
+        echo ""
+        ADDRESS_ARGS=(--address="$STATIC_IP")
+    else
+        echo "Using ephemeral external IP (recommended with wake proxy)."
+        echo "DNS should point at Cloud Run, not this VM. See DEPLOYMENT.md (Wake proxy)."
+        echo "To create a legacy static IP instead: USE_STATIC_IP=1 ./create-vm.sh"
+        echo ""
     fi
-    
-    # If still empty, try alternative method: list and filter
-    if [ -z "$STATIC_IP" ]; then
-        echo "WARNING: Could not retrieve IP with describe, trying list method..."
-        STATIC_IP=$(gcloud compute addresses list --project $PROJECT --filter="name=$INSTANCE-ip AND region:$REGION" --format="value(address)" 2>/dev/null | head -1 | tr -d '\r\n ')
-    fi
-    
-    # Final check - if still empty, show error and debug info
-    if [ -z "$STATIC_IP" ]; then
-        echo "ERROR: Failed to retrieve static IP address"
-        echo "Looking for IP named '$INSTANCE-ip' in region '$REGION'"
-        echo "Attempting to list all addresses to debug..."
-        gcloud compute addresses list --project $PROJECT --format="table(name,address,region)" 2>/dev/null || true
-        exit 1
-    fi
-    echo "Static IP address: $STATIC_IP"
-    echo ""
-    echo "IMPORTANT: Update your DNS A record for photogroup.network to point to: $STATIC_IP"
-    echo ""
     
     # Create firewall rules if they don't exist
     echo "Creating firewall rules..."
@@ -135,7 +147,7 @@ else
         --image-project=$IMAGE_PROJECT \
         --boot-disk-size=$DISK_SIZE \
         --boot-disk-type=pd-standard \
-        --address=$STATIC_IP \
+        "${ADDRESS_ARGS[@]}" \
         --tags=http-server,https-server \
         --metadata=startup-script='#!/bin/bash
         apt-get update
@@ -221,11 +233,16 @@ else
     echo "Zone: $ZONE"
     echo "External IP: $EXTERNAL_IP"
     echo ""
-    echo "NEXT STEPS:"
-    echo "1. Update DNS: Point photogroup.network A record to: $EXTERNAL_IP"
-    echo "2. Wait for DNS propagation (can take up to 48 hours, usually much faster)"
-    echo "3. Run SSL setup: ./setup-ssl.sh"
-    echo "4. Deploy application: ./deploy-all.sh"
+    echo "NEXT STEPS (wake-proxy architecture):"
+    echo "1. Deploy nginx + app: ./deploy-nginx.sh && ./deploy-docker.sh"
+    echo "2. Obtain SSL on the VM (for origin HTTPS): ./setup-ssl.sh"
+    echo "3. Deploy wake proxy: ./deploy-wake-proxy.sh"
+    echo "4. Point DNS at Cloud Run (see deploy-wake-proxy.sh output) — not at $EXTERNAL_IP"
+    echo "5. Release any legacy static IP: ./release-static-ip.sh"
+    echo ""
+    echo "Legacy (DNS → VM IP) NEXT STEPS:"
+    echo "1. Update DNS A record to: $EXTERNAL_IP  (only if USE_STATIC_IP=1)"
+    echo "2. ./setup-ssl.sh && ./deploy-all.sh"
     echo ""
 fi
 

--- a/deploy-wake-proxy.sh
+++ b/deploy-wake-proxy.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Deploy the PhotoGroup wake proxy to Cloud Run and (optionally) install VM idle-stop.
+#
+# Prerequisites:
+#   - gcloud authenticated with permission to deploy Cloud Run + manage IAM
+#   - Docker available locally (or Cloud Build)
+#
+# Usage:
+#   ./deploy-wake-proxy.sh
+#   WAKE_STOP_SECRET=... IDLE_MINUTES=60 ./deploy-wake-proxy.sh
+#   SKIP_IDLE_STOP=1 ./deploy-wake-proxy.sh   # deploy Cloud Run only
+
+set -euo pipefail
+
+ZONE="${ZONE:-asia-east2-a}"
+REGION="${REGION:-asia-east2}"
+INSTANCE="${INSTANCE:-main}"
+PROJECT="${PROJECT:-photogroup-215600}"
+SERVICE="${WAKE_SERVICE:-photogroup-wake}"
+IMAGE="gcr.io/${PROJECT}/${SERVICE}:latest"
+IDLE_MINUTES="${IDLE_MINUTES:-60}"
+SKIP_IDLE_STOP="${SKIP_IDLE_STOP:-0}"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=========================================="
+echo "Deploy PhotoGroup wake proxy"
+echo "=========================================="
+echo "Project:  $PROJECT"
+echo "Region:   $REGION"
+echo "Service:  $SERVICE"
+echo "VM:       $INSTANCE ($ZONE)"
+echo ""
+
+gcloud config set project "$PROJECT" >/dev/null
+
+# Enable required APIs (idempotent)
+gcloud services enable \
+  run.googleapis.com \
+  compute.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com \
+  --project "$PROJECT" >/dev/null
+
+# Service account for the wake proxy
+SA_NAME="photogroup-wake"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+if ! gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT" &>/dev/null; then
+  echo "Creating service account $SA_EMAIL..."
+  gcloud iam service-accounts create "$SA_NAME" \
+    --project "$PROJECT" \
+    --display-name "PhotoGroup wake proxy"
+fi
+
+# Grant start/stop/get on Compute Engine
+echo "Ensuring IAM roles on wake service account..."
+for ROLE in roles/compute.instanceAdmin.v1 roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="$ROLE" \
+    --condition=None \
+    >/dev/null 2>&1 || true
+done
+
+# Also allow the VM's own SA to stop itself (for idle-stop)
+VM_SA=$(gcloud compute instances describe "$INSTANCE" \
+  --project "$PROJECT" --zone "$ZONE" \
+  --format='get(serviceAccounts[0].email)' 2>/dev/null || true)
+if [ -n "${VM_SA:-}" ]; then
+  echo "Ensuring VM SA can stop itself: $VM_SA"
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${VM_SA}" \
+    --role="roles/compute.instanceAdmin.v1" \
+    --condition=None \
+    >/dev/null 2>&1 || true
+fi
+
+echo "Building and pushing image $IMAGE ..."
+export DOCKER_BUILDKIT=1
+docker build -t "$IMAGE" "$ROOT/wake-proxy"
+gcloud auth configure-docker --quiet
+docker push "$IMAGE"
+
+ENV_VARS="GCP_PROJECT=${PROJECT},GCE_ZONE=${ZONE},GCE_INSTANCE=${INSTANCE},ORIGIN_SCHEME=http,HEALTH_PATH=/api/__rtcConfig__,IDLE_MINUTES=${IDLE_MINUTES}"
+if [ -n "${WAKE_STOP_SECRET:-}" ]; then
+  ENV_VARS="${ENV_VARS},WAKE_STOP_SECRET=${WAKE_STOP_SECRET}"
+fi
+
+echo "Deploying Cloud Run service $SERVICE ..."
+gcloud run deploy "$SERVICE" \
+  --project "$PROJECT" \
+  --region "$REGION" \
+  --image "$IMAGE" \
+  --platform managed \
+  --allow-unauthenticated \
+  --port 8080 \
+  --memory 512Mi \
+  --cpu 1 \
+  --min-instances 0 \
+  --max-instances 3 \
+  --timeout 3600 \
+  --concurrency 80 \
+  --session-affinity \
+  --service-account "$SA_EMAIL" \
+  --set-env-vars "$ENV_VARS"
+
+SERVICE_URL=$(gcloud run services describe "$SERVICE" \
+  --project "$PROJECT" --region "$REGION" \
+  --format='value(status.url)')
+
+echo ""
+echo "Wake proxy URL: $SERVICE_URL"
+
+if [ "$SKIP_IDLE_STOP" != "1" ]; then
+  echo ""
+  IDLE_MINUTES="$IDLE_MINUTES" ZONE="$ZONE" INSTANCE="$INSTANCE" PROJECT="$PROJECT" \
+    bash "$ROOT/wake-proxy/vm-idle-stop/install-idle-stop.sh"
+fi
+
+echo ""
+echo "=========================================="
+echo "Next: point DNS at Cloud Run"
+echo "=========================================="
+echo "1) Map custom domains (if supported in $REGION):"
+echo "     gcloud beta run domain-mappings create --service $SERVICE --domain photogroup.network --region $REGION --project $PROJECT"
+echo "     gcloud beta run domain-mappings create --service $SERVICE --domain www.photogroup.network --region $REGION --project $PROJECT"
+echo "     gcloud beta run domain-mappings create --service $SERVICE --domain hackernews.photogroup.network --region $REGION --project $PROJECT"
+echo "   Then add the DNS records Cloud Run prints (replace your old A record)."
+echo ""
+echo "   OR use Cloudflare: CNAME each hostname to the run.app host of:"
+echo "     $SERVICE_URL"
+echo "   (proxy/orange-cloud ON)."
+echo ""
+echo "2) Release the unused static IP to save ~\$3.65/mo:"
+echo "     ./release-static-ip.sh"
+echo ""
+echo "3) Verify:"
+echo "     curl -sS $SERVICE_URL/__wake__/status"
+echo "     open $SERVICE_URL  # should show starting page then the app"
+echo ""

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "deploy-only": "cd server && npm run deploy",
     "test": "node test-all.js",
     "test:server": "cd server && npm test",
+    "test:wake-proxy": "cd wake-proxy && npm test",
     "test:ui": "cd ui && npm test -- --run",
     "test:e2e": "cd ui && npm run test:e2e",
     "test:e2e:side-by-side": "cd ui && npm run test:e2e:side-by-side",

--- a/release-static-ip.sh
+++ b/release-static-ip.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Release the reserved regional static IP used by the PhotoGroup VM.
+# After DNS points at Cloud Run, the VM should use an ephemeral IP only
+# (assigned automatically when the instance starts).
+#
+# Usage:
+#   ./release-static-ip.sh
+#   ./release-static-ip.sh --dry-run
+
+set -euo pipefail
+
+ZONE="${ZONE:-asia-east2-a}"
+REGION="${ZONE%-*}"
+INSTANCE="${INSTANCE:-main}"
+PROJECT="${PROJECT:-photogroup-215600}"
+ADDRESS_NAME="${ADDRESS_NAME:-${INSTANCE}-ip}"
+DRY_RUN=0
+
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+
+echo "Release static IP '$ADDRESS_NAME' in $REGION (project $PROJECT)"
+echo ""
+
+CURRENT_IP=$(gcloud compute addresses describe "$ADDRESS_NAME" \
+  --project "$PROJECT" --region "$REGION" \
+  --format='value(address)' 2>/dev/null || true)
+
+if [ -z "$CURRENT_IP" ]; then
+  echo "No reserved address named '$ADDRESS_NAME' — nothing to do."
+  exit 0
+fi
+
+echo "Found reserved IP: $CURRENT_IP"
+
+STATUS=$(gcloud compute addresses describe "$ADDRESS_NAME" \
+  --project "$PROJECT" --region "$REGION" \
+  --format='value(status)' 2>/dev/null || true)
+echo "Address status: $STATUS"
+
+# Detach from VM access config if still attached
+if gcloud compute instances describe "$INSTANCE" --project "$PROJECT" --zone "$ZONE" &>/dev/null; then
+  NIC=$(gcloud compute instances describe "$INSTANCE" --project "$PROJECT" --zone "$ZONE" \
+    --format='value(networkInterfaces[0].name)' 2>/dev/null || echo "nic0")
+  ACCESS=$(gcloud compute instances describe "$INSTANCE" --project "$PROJECT" --zone "$ZONE" \
+    --format='value(networkInterfaces[0].accessConfigs[0].name)' 2>/dev/null || true)
+  VM_IP=$(gcloud compute instances describe "$INSTANCE" --project "$PROJECT" --zone "$ZONE" \
+    --format='value(networkInterfaces[0].accessConfigs[0].natIP)' 2>/dev/null || true)
+
+  if [ -n "$ACCESS" ] && [ "$VM_IP" = "$CURRENT_IP" ]; then
+    echo "Detaching static IP from $INSTANCE ($ACCESS on $NIC)..."
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "DRY-RUN: would delete-access-config + add ephemeral access-config"
+    else
+      # Remove static access config
+      gcloud compute instances delete-access-config "$INSTANCE" \
+        --project "$PROJECT" --zone "$ZONE" \
+        --access-config-name="$ACCESS" \
+        --network-interface="$NIC" || true
+      # Add ephemeral external IP so the VM remains reachable when running
+      gcloud compute instances add-access-config "$INSTANCE" \
+        --project "$PROJECT" --zone "$ZONE" \
+        --network-interface="$NIC" \
+        --access-config-name="External NAT" || true
+      echo "VM now uses an ephemeral external IP (released when stopped)."
+    fi
+  else
+    echo "VM is not using $CURRENT_IP (or has no access config) — skipping detach."
+  fi
+fi
+
+echo "Deleting reserved address $ADDRESS_NAME..."
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY-RUN: would delete address $ADDRESS_NAME"
+else
+  gcloud compute addresses delete "$ADDRESS_NAME" \
+    --project "$PROJECT" --region "$REGION" --quiet
+  echo "Static IP released. Savings ≈ \$3.65/month when the VM is stopped."
+fi

--- a/server/config/photogroup.network
+++ b/server/config/photogroup.network
@@ -8,22 +8,66 @@ map $http_upgrade $connection_upgrade {
     ''              close;
 }
 
-# HTTP redirect blocks (port 80 only) - redirect all HTTP traffic to HTTPS
+# Wake proxy (Cloud Run) talks HTTP to this VM and sets X-Wake-Proxy: 1.
+# Direct browsers on :80 still redirect to HTTPS (legacy / accidental IP hits).
+map $http_x_wake_proxy $wake_http_ok {
+    default 0;
+    "1"     1;
+}
+
+# HTTP — wake-proxy origin OR redirect to HTTPS
 server {
         listen 80;
         listen [::]:80;
         server_name photogroup.network www.photogroup.network;
-        return 301 https://$server_name$request_uri;
+
+        location / {
+                if ($wake_http_ok = 0) {
+                        return 301 https://$host$request_uri;
+                }
+
+                proxy_pass "http://127.0.0.1:8081/";
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+                proxy_set_header X-Real-Port $server_port;
+                proxy_set_header X-Real-Scheme $scheme;
+        }
+
+        location /ws {
+                if ($wake_http_ok = 0) {
+                        return 301 https://$host$request_uri;
+                }
+
+                proxy_pass          http://127.0.0.1:9000;
+                proxy_http_version  1.1;
+                proxy_set_header    Upgrade     $http_upgrade;
+                proxy_set_header    Connection  $connection_upgrade;
+                proxy_set_header    Host        $http_host;
+                proxy_set_header    X-Wake-Proxy $http_x_wake_proxy;
+        }
 }
 
 server {
         listen 80;
         listen [::]:80;
         server_name hackernews.photogroup.network;
-        return 301 https://$server_name$request_uri;
+
+        location / {
+                if ($wake_http_ok = 0) {
+                        return 301 https://$host$request_uri;
+                }
+
+                proxy_pass "http://127.0.0.1:18080/";
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        }
 }
 
-# HTTPS server blocks (port 443 only) - handle all actual requests over HTTPS
+# HTTPS server blocks (port 443) — optional direct access / legacy DNS→VM
 server {
         listen 443 ssl;
         listen [::]:443 ssl;

--- a/test-all.js
+++ b/test-all.js
@@ -250,6 +250,7 @@ async function main() {
     serverUnit: null,
     serverAPI: null,
     serverIntegration: null,
+    wakeProxy: null,
     uiUnit: null,
     uiE2E: null,
   };
@@ -257,6 +258,7 @@ async function main() {
   const rootDir = __dirname;
   const serverDir = path.join(rootDir, 'server');
   const uiDir = path.join(rootDir, 'ui');
+  const wakeProxyDir = path.join(rootDir, 'wake-proxy');
 
   // Check if server is running (needed for e2e tests)
   let serverRunning = false;
@@ -309,6 +311,13 @@ async function main() {
       serverDir,
       'Server Integration Tests'
     );
+
+    // 3b. Wake proxy unit tests
+    results.wakeProxy = await runCommand(
+      'npm test',
+      wakeProxyDir,
+      'Wake Proxy Unit Tests'
+    );
   }
 
   if (!serverOnly && !e2eOnly) {
@@ -351,6 +360,7 @@ async function main() {
     { name: 'Server Unit Tests', result: results.serverUnit },
     { name: 'Server API Tests', result: results.serverAPI },
     { name: 'Server Integration Tests', result: results.serverIntegration },
+    { name: 'Wake Proxy Unit Tests', result: results.wakeProxy },
     { name: 'UI Unit Tests', result: results.uiUnit },
     { name: 'UI E2E Tests', result: results.uiE2E },
   ];

--- a/wake-proxy/.dockerignore
+++ b/wake-proxy/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log*
+Dockerfile
+README.md
+tests
+vm-idle-stop

--- a/wake-proxy/Dockerfile
+++ b/wake-proxy/Dockerfile
@@ -1,0 +1,17 @@
+# Wake proxy — Cloud Run service that boots the GCE VM on demand
+FROM node:24-alpine
+
+WORKDIR /app
+
+RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001
+
+COPY package.json ./
+RUN npm install --omit=dev && npm cache clean --force
+
+COPY src ./src
+
+USER nodejs
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["node", "src/index.js"]

--- a/wake-proxy/README.md
+++ b/wake-proxy/README.md
@@ -1,0 +1,57 @@
+# PhotoGroup wake proxy
+
+Cloud Run front door that **starts the GCE VM on demand**, shows a cold-start page, then reverse-proxies HTTP and WebSocket traffic to nginx on the VM.
+
+## Architecture
+
+```
+Browser → Cloud Run (this service, asia-east2)
+            ├─ VM stopped → GCE Start API → wait for /api/__rtcConfig__
+            └─ VM running → HTTPS proxy to ephemeral VM IP (Host header preserved)
+VM idle-stop timer → stops instance after ~60 minutes without nginx traffic
+```
+
+When the VM is **stopped**, its ephemeral external IP is released → **~$0/month** idle cost (disk within free tier). DNS points at Cloud Run, not the VM.
+
+## Local development
+
+```bash
+cd wake-proxy
+npm install
+GCP_PROJECT=photogroup-215600 GCE_ZONE=asia-east2-a GCE_INSTANCE=main npm start
+npm test
+```
+
+Requires Application Default Credentials with `compute.instances.get/start/stop`.
+
+## Deploy
+
+From the repo root:
+
+```bash
+./deploy-wake-proxy.sh
+```
+
+Then map DNS to the Cloud Run service (see script output) and run `./release-static-ip.sh`.
+
+## Endpoints
+
+| Path | Purpose |
+|------|---------|
+| `/__wake__/healthz` | Liveness (does **not** start the VM) |
+| `/__wake__/status` | JSON boot status for the starting page |
+| `/__wake__/stop` | POST + `X-Wake-Stop-Secret` — stop the VM (optional) |
+| `/*` | Start VM if needed, then proxy to origin |
+
+## Environment
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `GCP_PROJECT` | `photogroup-215600` | Project |
+| `GCE_ZONE` | `asia-east2-a` | VM zone |
+| `GCE_INSTANCE` | `main` | VM name |
+| `ORIGIN_SCHEME` | `http` | Scheme to talk to nginx (`http` recommended; set `X-Wake-Proxy: 1`) |
+| `HEALTH_PATH` | `/api/__rtcConfig__` | Readiness probe |
+| `READY_TIMEOUT_MS` | `180000` | Max wait for origin |
+| `WAKE_STOP_SECRET` | _(empty)_ | Enables `/__wake__/stop` |
+| `IDLE_MINUTES` | `60` | Hint shown on starting page |

--- a/wake-proxy/package-lock.json
+++ b/wake-proxy/package-lock.json
@@ -1,0 +1,1399 @@
+{
+  "name": "photogroup-wake-proxy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "photogroup-wake-proxy",
+      "version": "1.0.0",
+      "dependencies": {
+        "@google-cloud/compute": "^6.13.0",
+        "http-proxy": "^1.18.1"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@google-cloud/compute": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/compute/-/compute-6.13.0.tgz",
+      "integrity": "sha512-lTMcF4iNHc4W5VL9+3FuY8IrOFAQHG5Tq0teSvbVbnHxkwdH+ny87NOAgTSgpG/cfS5gMRtZFN14OQRe5EUC4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/wake-proxy/package.json
+++ b/wake-proxy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "photogroup-wake-proxy",
+  "version": "1.0.0",
+  "description": "Cloud Run wake proxy that starts the PhotoGroup GCE VM on demand and reverse-proxies traffic",
+  "type": "module",
+  "main": "src/index.js",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test tests/*.test.js"
+  },
+  "dependencies": {
+    "@google-cloud/compute": "^6.13.0",
+    "http-proxy": "^1.18.1"
+  }
+}

--- a/wake-proxy/src/config.js
+++ b/wake-proxy/src/config.js
@@ -1,0 +1,39 @@
+/**
+ * Runtime configuration for the wake proxy.
+ * All values are overridable via environment variables for Cloud Run.
+ */
+
+function intEnv(env, name, fallback) {
+  const raw = env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function loadConfig(env = process.env) {
+  return {
+    port: intEnv(env, 'PORT', 8080),
+    projectId: env.GCP_PROJECT || env.GOOGLE_CLOUD_PROJECT || 'photogroup-215600',
+    zone: env.GCE_ZONE || 'asia-east2-a',
+    instance: env.GCE_INSTANCE || 'main',
+    /** Origin scheme when talking to the VM (nginx TLS). */
+    originScheme: env.ORIGIN_SCHEME || 'http',
+    /** Health path on the origin (must return 200 when app is ready). */
+    healthPath: env.HEALTH_PATH || '/api/__rtcConfig__',
+    /** How long to wait for VM + app readiness before giving up (ms). */
+    readyTimeoutMs: intEnv(env, 'READY_TIMEOUT_MS', 180_000),
+    /** Interval between health polls (ms). */
+    healthPollMs: intEnv(env, 'HEALTH_POLL_MS', 3_000),
+    /** Rate-limit VM start attempts (ms). */
+    startCooldownMs: intEnv(env, 'START_COOLDOWN_MS', 30_000),
+    /**
+     * Shared secret for /__wake__/stop (Cloud Scheduler / admin).
+     * If empty, stop endpoint is disabled.
+     */
+    stopSecret: env.WAKE_STOP_SECRET || '',
+    /**
+     * Idle minutes used only for status reporting; actual auto-stop runs on the VM.
+     */
+    idleMinutesHint: intEnv(env, 'IDLE_MINUTES', 60),
+  };
+}

--- a/wake-proxy/src/gce.js
+++ b/wake-proxy/src/gce.js
@@ -1,0 +1,261 @@
+/**
+ * Thin wrapper around the Compute Engine API for start / stop / status / IP.
+ */
+import compute from '@google-cloud/compute';
+
+const { InstancesClient, ZoneOperationsClient } = compute;
+
+export class GceController {
+  /**
+   * @param {{ projectId: string, zone: string, instance: string }} opts
+   * @param {{ instances?: import('@google-cloud/compute').InstancesClient, operations?: import('@google-cloud/compute').ZoneOperationsClient }} [clients]
+   */
+  constructor(opts, clients = {}) {
+    this.projectId = opts.projectId;
+    this.zone = opts.zone;
+    this.instance = opts.instance;
+    this.instances = clients.instances || new InstancesClient();
+    this.operations = clients.operations || new ZoneOperationsClient();
+    this._lastStartAttempt = 0;
+  }
+
+  async getInstance() {
+    const [vm] = await this.instances.get({
+      project: this.projectId,
+      zone: this.zone,
+      instance: this.instance,
+    });
+    return vm;
+  }
+
+  /**
+   * @returns {Promise<{ status: string, externalIp: string|null, name: string }>}
+   */
+  async getStatus() {
+    const vm = await this.getInstance();
+    const status = vm.status || 'UNKNOWN';
+    const nic = vm.networkInterfaces?.[0];
+    const access = nic?.accessConfigs?.[0];
+    const externalIp = access?.natIP || null;
+    return {
+      status,
+      externalIp,
+      name: vm.name || this.instance,
+    };
+  }
+
+  /**
+   * Start the VM if it is not already running / provisioning.
+   * Rate-limited by cooldownMs.
+   * @param {number} cooldownMs
+   * @returns {Promise<{ started: boolean, status: string, externalIp: string|null, skipped?: string }>}
+   */
+  async ensureStarted(cooldownMs = 30_000) {
+    const current = await this.getStatus();
+    if (current.status === 'RUNNING') {
+      return { started: false, ...current };
+    }
+    if (current.status === 'STAGING' || current.status === 'PROVISIONING') {
+      return { started: false, ...current };
+    }
+
+    const now = Date.now();
+    if (now - this._lastStartAttempt < cooldownMs) {
+      return {
+        started: false,
+        skipped: 'cooldown',
+        ...current,
+      };
+    }
+    this._lastStartAttempt = now;
+
+    const [operation] = await this.instances.start({
+      project: this.projectId,
+      zone: this.zone,
+      instance: this.instance,
+    });
+
+    if (operation?.name) {
+      await this.operations.wait({
+        project: this.projectId,
+        zone: this.zone,
+        operation: operation.name,
+      });
+    }
+
+    const after = await this.getStatus();
+    return { started: true, ...after };
+  }
+
+  /**
+   * Stop the VM if it is running.
+   */
+  async ensureStopped() {
+    const current = await this.getStatus();
+    if (current.status === 'TERMINATED' || current.status === 'STOPPED') {
+      return { stopped: false, ...current };
+    }
+
+    const [operation] = await this.instances.stop({
+      project: this.projectId,
+      zone: this.zone,
+      instance: this.instance,
+    });
+
+    if (operation?.name) {
+      await this.operations.wait({
+        project: this.projectId,
+        zone: this.zone,
+        operation: operation.name,
+      });
+    }
+
+    const after = await this.getStatus();
+    return { stopped: true, ...after };
+  }
+}
+
+/**
+ * Poll until the origin health endpoint returns 200, or timeout.
+ * @param {{ scheme: string, ip: string, host: string, path: string, timeoutMs: number, pollMs: number, fetchImpl?: typeof fetch }} opts
+ */
+export async function waitForHealthy(opts) {
+  const {
+    scheme,
+    ip,
+    host,
+    path,
+    timeoutMs,
+    pollMs,
+    fetchImpl = fetch,
+  } = opts;
+
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    if (!ip) {
+      lastError = new Error('no external IP yet');
+      await sleep(pollMs);
+      continue;
+    }
+
+    try {
+      const url = `${scheme}://${ip}${path}`;
+      const res = await fetchImpl(url, {
+        method: 'GET',
+        headers: { Host: host, Accept: 'application/json' },
+        // Node undici / fetch: allow self-signed / hostname mismatch for IP targets
+        // (nodejs native fetch does not support rejectUnauthorized; we use https agent in probe)
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (res.ok) {
+        return { healthy: true };
+      }
+      lastError = new Error(`health status ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await sleep(pollMs);
+  }
+
+  return {
+    healthy: false,
+    error: lastError?.message || 'timeout',
+  };
+}
+
+/**
+ * HTTPS health probe that tolerates certificate hostname mismatch (IP target).
+ * Uses Node https module so we can set rejectUnauthorized: false.
+ */
+export async function probeOriginHttps({ ip, host, path, timeoutMs = 5_000 }) {
+  const https = await import('node:https');
+  return new Promise((resolve) => {
+    const req = https.request(
+      {
+        host: ip,
+        port: 443,
+        path,
+        method: 'GET',
+        headers: { Host: host, Accept: 'application/json', 'X-Wake-Proxy': '1' },
+        rejectUnauthorized: false,
+        servername: host,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        res.resume();
+        resolve({ ok: res.statusCode >= 200 && res.statusCode < 400, status: res.statusCode });
+      }
+    );
+    req.on('error', (err) => resolve({ ok: false, error: err.message }));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ ok: false, error: 'timeout' });
+    });
+    req.end();
+  });
+}
+
+/**
+ * HTTP health probe for wake-proxy → nginx :80 (preferred when DNS is on Cloud Run).
+ */
+export async function probeOriginHttp({ ip, host, path, timeoutMs = 5_000 }) {
+  const http = await import('node:http');
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        host: ip,
+        port: 80,
+        path,
+        method: 'GET',
+        headers: { Host: host, Accept: 'application/json', 'X-Wake-Proxy': '1' },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        res.resume();
+        resolve({ ok: res.statusCode >= 200 && res.statusCode < 400, status: res.statusCode });
+      }
+    );
+    req.on('error', (err) => resolve({ ok: false, error: err.message }));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ ok: false, error: 'timeout' });
+    });
+    req.end();
+  });
+}
+
+/**
+ * Wait until origin is healthy (HTTP or HTTPS to ephemeral IP).
+ */
+export async function waitForOriginReady(opts) {
+  const { ip, host, path, timeoutMs, pollMs, getIp, scheme = 'http' } = opts;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = 'waiting';
+  let currentIp = ip;
+  const probe = scheme === 'https' ? probeOriginHttps : probeOriginHttp;
+
+  while (Date.now() < deadline) {
+    if (typeof getIp === 'function') {
+      currentIp = await getIp();
+    }
+    if (!currentIp) {
+      lastError = 'no external IP yet';
+      await sleep(pollMs);
+      continue;
+    }
+    const result = await probe({ ip: currentIp, host, path });
+    if (result.ok) {
+      return { healthy: true, ip: currentIp };
+    }
+    lastError = result.error || `status ${result.status}`;
+    await sleep(pollMs);
+  }
+
+  return { healthy: false, error: lastError, ip: currentIp };
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/wake-proxy/src/index.js
+++ b/wake-proxy/src/index.js
@@ -1,0 +1,252 @@
+/**
+ * PhotoGroup wake proxy — Cloud Run ingress that starts the GCE VM on demand
+ * and reverse-proxies HTTP/WebSocket traffic to nginx on the VM.
+ */
+import http from 'node:http';
+import { loadConfig } from './config.js';
+import { GceController, waitForOriginReady } from './gce.js';
+import { createOriginProxy, proxyHttp, proxyWs, wantsHtml } from './proxy.js';
+import { renderStartingPage } from './starting-page.js';
+
+const config = loadConfig();
+const gce = new GceController(config);
+const proxy = createOriginProxy();
+
+/** @type {{ phase: string, ready: boolean, message: string, externalIp: string|null, updatedAt: number }} */
+let wakeState = {
+  phase: 'idle',
+  ready: false,
+  message: 'Idle',
+  externalIp: null,
+  updatedAt: Date.now(),
+};
+
+/** In-flight ensure-ready promise so concurrent requests share one boot. */
+let ensureReadyPromise = null;
+
+function setState(patch) {
+  wakeState = { ...wakeState, ...patch, updatedAt: Date.now() };
+}
+
+function brandForHost(host = '') {
+  if (host.startsWith('hackernews.')) return 'Hackersbot';
+  return 'PhotoGroup';
+}
+
+/**
+ * Ensure VM is running and origin is healthy. Returns origin target or throws.
+ */
+async function ensureReady(host) {
+  if (ensureReadyPromise) return ensureReadyPromise;
+
+  ensureReadyPromise = (async () => {
+    try {
+      setState({ phase: 'starting', ready: false, message: 'Starting VM…' });
+      const started = await gce.ensureStarted(config.startCooldownMs);
+      setState({
+        phase: 'booting',
+        ready: false,
+        message: `VM ${started.status}`,
+        externalIp: started.externalIp,
+      });
+
+      setState({ phase: 'waiting_health', message: 'Waiting for app health…' });
+      const ready = await waitForOriginReady({
+        ip: started.externalIp,
+        host: host.split(':')[0],
+        path: config.healthPath,
+        timeoutMs: config.readyTimeoutMs,
+        pollMs: config.healthPollMs,
+        scheme: config.originScheme,
+        getIp: async () => {
+          const s = await gce.getStatus();
+          if (s.externalIp) setState({ externalIp: s.externalIp });
+          return s.externalIp;
+        },
+      });
+
+      if (!ready.healthy || !ready.ip) {
+        setState({
+          phase: 'error',
+          ready: false,
+          message: ready.error || 'Origin not healthy',
+        });
+        throw new Error(ready.error || 'Origin not healthy');
+      }
+
+      setState({
+        phase: 'ready',
+        ready: true,
+        message: 'Ready',
+        externalIp: ready.ip,
+      });
+      return { scheme: config.originScheme, ip: ready.ip };
+    } finally {
+      // Allow a later retry after failure; keep success cached via wakeState.ready
+      ensureReadyPromise = null;
+    }
+  })();
+
+  return ensureReadyPromise;
+}
+
+async function handleWakeStatus(_req, res) {
+  // Opportunistically refresh status if we think we are ready
+  if (wakeState.ready && wakeState.externalIp) {
+    const probeHost = 'photogroup.network';
+    try {
+      const { probeOriginHttp, probeOriginHttps } = await import('./gce.js');
+      const probeFn = config.originScheme === 'https' ? probeOriginHttps : probeOriginHttp;
+      const probe = await probeFn({
+        ip: wakeState.externalIp,
+        host: probeHost,
+        path: config.healthPath,
+      });
+      if (!probe.ok) {
+        setState({ ready: false, phase: 'waiting_health', message: 'Origin lost health' });
+      }
+    } catch {
+      // ignore probe errors in status
+    }
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify({
+    ...wakeState,
+    projectId: config.projectId,
+    zone: config.zone,
+    instance: config.instance,
+    idleMinutesHint: config.idleMinutesHint,
+  }));
+}
+
+async function handleWakeStop(req, res) {
+  if (!config.stopSecret) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'stop endpoint disabled' }));
+    return;
+  }
+  const provided = req.headers['x-wake-stop-secret'] || '';
+  if (provided !== config.stopSecret) {
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'unauthorized' }));
+    return;
+  }
+
+  try {
+    const result = await gce.ensureStopped();
+    setState({
+      phase: 'idle',
+      ready: false,
+      message: 'Stopped',
+      externalIp: null,
+    });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(result));
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
+async function handleRequest(req, res) {
+  const url = req.url || '/';
+  const path = url.split('?')[0];
+  const host = req.headers.host || 'photogroup.network';
+
+  if (path === '/__wake__/status') {
+    return handleWakeStatus(req, res);
+  }
+  if (path === '/__wake__/stop' && req.method === 'POST') {
+    return handleWakeStop(req, res);
+  }
+  // Cloud Run / LB health checks — do not start the VM
+  if (path === '/__wake__/healthz' || path === '/robots.txt') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(path === '/robots.txt' ? 'User-agent: *\nDisallow: /\n' : 'ok');
+    return;
+  }
+
+  // Fast path: already ready
+  if (wakeState.ready && wakeState.externalIp) {
+    return proxyHttp(proxy, req, res, {
+      scheme: config.originScheme,
+      ip: wakeState.externalIp,
+    });
+  }
+
+  // Browser navigations get the starting page immediately while boot continues
+  if (wantsHtml(req)) {
+    // Kick off boot without awaiting
+    ensureReady(host).catch((err) => {
+      console.error('[wake-proxy] ensureReady failed:', err.message);
+    });
+    const html = renderStartingPage({
+      brand: brandForHost(host),
+      statusText: 'Starting the server…',
+      idleMinutes: config.idleMinutesHint,
+    });
+    res.writeHead(503, {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'Retry-After': '15',
+    });
+    res.end(html);
+    return;
+  }
+
+  // API / non-HTML: wait for ready then proxy (or 503)
+  try {
+    const target = await ensureReady(host);
+    return proxyHttp(proxy, req, res, target);
+  } catch (err) {
+    res.writeHead(503, {
+      'Content-Type': 'application/json',
+      'Retry-After': '30',
+      'Cache-Control': 'no-store',
+    });
+    res.end(JSON.stringify({
+      error: 'origin_starting',
+      message: err.message,
+      phase: wakeState.phase,
+    }));
+  }
+}
+
+const server = http.createServer((req, res) => {
+  handleRequest(req, res).catch((err) => {
+    console.error('[wake-proxy] unhandled:', err);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal error');
+    }
+  });
+});
+
+server.on('upgrade', (req, socket, head) => {
+  const host = req.headers.host || 'photogroup.network';
+
+  const go = async () => {
+    try {
+      let target;
+      if (wakeState.ready && wakeState.externalIp) {
+        target = { scheme: config.originScheme, ip: wakeState.externalIp };
+      } else {
+        target = await ensureReady(host);
+      }
+      proxyWs(proxy, req, socket, head, target);
+    } catch (err) {
+      console.error('[wake-proxy] ws upgrade failed:', err.message);
+      socket.destroy();
+    }
+  };
+  go();
+});
+
+server.listen(config.port, () => {
+  console.log(`[wake-proxy] listening on :${config.port}`);
+  console.log(`[wake-proxy] target VM ${config.projectId}/${config.zone}/${config.instance}`);
+});

--- a/wake-proxy/src/proxy.js
+++ b/wake-proxy/src/proxy.js
@@ -1,0 +1,115 @@
+/**
+ * Reverse-proxy helpers for HTTP and WebSocket traffic to the VM origin.
+ */
+import httpProxy from 'http-proxy';
+import https from 'node:https';
+import http from 'node:http';
+
+const httpsAgentCache = new Map();
+const httpAgent = new http.Agent({ keepAlive: true });
+
+function httpsAgentFor(servername) {
+  const key = servername || '_';
+  let agent = httpsAgentCache.get(key);
+  if (!agent) {
+    agent = new https.Agent({
+      rejectUnauthorized: false,
+      keepAlive: true,
+      servername: servername || undefined,
+    });
+    httpsAgentCache.set(key, agent);
+  }
+  return agent;
+}
+
+/**
+ * Create an http-proxy instance for VM origins.
+ */
+export function createOriginProxy() {
+  const proxy = httpProxy.createProxyServer({
+    ws: true,
+    xfwd: true,
+    changeOrigin: false,
+  });
+
+  proxy.on('error', (err, _req, res) => {
+    console.error('[wake-proxy] proxy error:', err.message);
+    if (res && !res.headersSent && typeof res.writeHead === 'function') {
+      res.writeHead(502, { 'Content-Type': 'text/plain' });
+      res.end('Origin unavailable');
+    } else if (res && typeof res.end === 'function') {
+      try {
+        res.end();
+      } catch {
+        // ignore
+      }
+    } else if (res && typeof res.destroy === 'function') {
+      res.destroy();
+    }
+  });
+
+  return proxy;
+}
+
+function originHost(req) {
+  return (req.headers.host || 'photogroup.network').split(':')[0];
+}
+
+function proxyHeaders(req) {
+  return {
+    Host: originHost(req),
+    'X-Wake-Proxy': '1',
+  };
+}
+
+/**
+ * @param {import('http-proxy')} proxy
+ * @param {import('http').IncomingMessage} req
+ * @param {import('http').ServerResponse} res
+ * @param {{ scheme: string, ip: string }} target
+ */
+export function proxyHttp(proxy, req, res, target) {
+  const host = originHost(req);
+  const isHttps = target.scheme === 'https';
+  proxy.web(req, res, {
+    target: `${target.scheme}://${target.ip}`,
+    secure: false,
+    agent: isHttps ? httpsAgentFor(host) : httpAgent,
+    headers: proxyHeaders(req),
+  });
+}
+
+/**
+ * @param {import('http-proxy')} proxy
+ * @param {import('http').IncomingMessage} req
+ * @param {import('stream').Duplex} socket
+ * @param {Buffer} head
+ * @param {{ scheme: string, ip: string }} target
+ */
+export function proxyWs(proxy, req, socket, head, target) {
+  const host = originHost(req);
+  const isHttps = target.scheme === 'https';
+  proxy.ws(req, socket, head, {
+    target: `${target.scheme}://${target.ip}`,
+    secure: false,
+    agent: isHttps ? httpsAgentFor(host) : httpAgent,
+    headers: proxyHeaders(req),
+  });
+}
+
+/**
+ * Whether this request should get an HTML starting page instead of a JSON/API error.
+ */
+export function wantsHtml(req) {
+  const accept = req.headers.accept || '';
+  const dest = req.headers['sec-fetch-dest'] || '';
+  if (dest === 'document') return true;
+  if (accept.includes('text/html')) return true;
+  if (!accept || accept === '*/*') {
+    const path = req.url?.split('?')[0] || '/';
+    if (!path.startsWith('/api/') && !path.startsWith('/__wake__/') && !path.startsWith('/ws')) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/wake-proxy/src/starting-page.js
+++ b/wake-proxy/src/starting-page.js
@@ -1,0 +1,156 @@
+/**
+ * Cold-start HTML shown while the GCE VM is booting.
+ * Uses @starting-style for entry motion; respects prefers-reduced-motion.
+ */
+export function renderStartingPage({ brand = 'PhotoGroup', statusText = 'Starting the server…', idleMinutes = 60 } = {}) {
+  const safeBrand = escapeHtml(brand);
+  const safeStatus = escapeHtml(statusText);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <title>${safeBrand} — Starting</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg0: #0b1c1a;
+      --bg1: #14322d;
+      --ink: #f2f7f4;
+      --muted: #a8c0b8;
+      --accent: #3dd6c3;
+      --accent-dim: #1f8f84;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      font-family: "IBM Plex Sans", system-ui, sans-serif;
+      color: var(--ink);
+      background:
+        radial-gradient(1200px 600px at 10% -10%, #1d4d45 0%, transparent 55%),
+        radial-gradient(900px 500px at 100% 0%, #0e3a4a 0%, transparent 50%),
+        linear-gradient(160deg, var(--bg0), var(--bg1));
+    }
+    main {
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 2rem 1.25rem;
+    }
+    .panel {
+      width: min(28rem, 100%);
+      text-align: center;
+      opacity: 1;
+      translate: 0;
+      transition: opacity 0.5s ease, translate 0.5s ease;
+      transition-behavior: allow-discrete;
+    }
+    @starting-style {
+      .panel {
+        opacity: 0;
+        translate: 0 16px;
+      }
+    }
+    .brand {
+      font-family: Fraunces, Georgia, serif;
+      font-weight: 700;
+      font-size: clamp(2rem, 6vw, 2.75rem);
+      letter-spacing: -0.02em;
+      margin: 0 0 0.75rem;
+    }
+    .status {
+      margin: 0;
+      color: var(--muted);
+      font-size: 1.05rem;
+      line-height: 1.5;
+    }
+    .bar {
+      margin: 1.75rem auto 0;
+      width: min(16rem, 80%);
+      height: 4px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--accent-dim) 40%, transparent);
+      overflow: hidden;
+    }
+    .bar > span {
+      display: block;
+      height: 100%;
+      width: 40%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+      animation: slide 1.4s ease-in-out infinite;
+    }
+    @keyframes slide {
+      0% { transform: translateX(-120%); }
+      100% { transform: translateX(280%); }
+    }
+    .hint {
+      margin-top: 1.5rem;
+      font-size: 0.85rem;
+      color: color-mix(in srgb, var(--muted) 80%, transparent);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .panel { transition-duration: 0.01ms; translate: none; }
+      @starting-style { .panel { translate: none; } }
+      .bar > span { animation: none; width: 100%; opacity: 0.7; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="panel" role="status" aria-live="polite">
+      <h1 class="brand">${safeBrand}</h1>
+      <p class="status" id="status">${safeStatus}</p>
+      <div class="bar" aria-hidden="true"><span></span></div>
+      <p class="hint">Cold start usually takes 1–2 minutes. The app auto-sleeps after about ${idleMinutes} minutes idle.</p>
+    </div>
+  </main>
+  <script>
+    (function () {
+      const statusEl = document.getElementById('status');
+      const started = Date.now();
+      let tries = 0;
+
+      async function tick() {
+        tries += 1;
+        const elapsed = Math.round((Date.now() - started) / 1000);
+        try {
+          const res = await fetch('/__wake__/status', { cache: 'no-store' });
+          const data = await res.json();
+          if (data.ready) {
+            statusEl.textContent = 'Ready — loading…';
+            window.location.replace(window.location.pathname + window.location.search + window.location.hash);
+            return;
+          }
+          if (data.phase === 'starting' || data.phase === 'booting') {
+            statusEl.textContent = 'Starting the server… (' + elapsed + 's)';
+          } else if (data.phase === 'waiting_health') {
+            statusEl.textContent = 'Almost there — waiting for the app… (' + elapsed + 's)';
+          } else {
+            statusEl.textContent = (data.message || 'Waking up…') + ' (' + elapsed + 's)';
+          }
+        } catch (_) {
+          statusEl.textContent = 'Connecting… (' + elapsed + 's)';
+        }
+        const delay = tries < 10 ? 2000 : 4000;
+        setTimeout(tick, delay);
+      }
+      setTimeout(tick, 1500);
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/wake-proxy/tests/gce.test.js
+++ b/wake-proxy/tests/gce.test.js
@@ -1,0 +1,82 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { GceController } from '../src/gce.js';
+
+function makeClients({ status = 'TERMINATED', natIP = null, startCalls = [] } = {}) {
+  const instances = {
+    get: mock.fn(async () => [{
+      status,
+      name: 'main',
+      networkInterfaces: [{
+        accessConfigs: [{ natIP }],
+      }],
+    }]),
+    start: mock.fn(async () => {
+      startCalls.push('start');
+      status = 'RUNNING';
+      natIP = '203.0.113.10';
+      return [{ name: 'op-start' }];
+    }),
+    stop: mock.fn(async () => {
+      status = 'TERMINATED';
+      natIP = null;
+      return [{ name: 'op-stop' }];
+    }),
+  };
+  const operations = {
+    wait: mock.fn(async () => [{}]),
+  };
+  return { instances, operations, startCalls, getStatus: () => status, getIp: () => natIP };
+}
+
+describe('GceController', () => {
+  it('ensureStarted starts a terminated VM', async () => {
+    const clients = makeClients({ status: 'TERMINATED' });
+    const gce = new GceController(
+      { projectId: 'p', zone: 'z', instance: 'main' },
+      clients
+    );
+    const result = await gce.ensureStarted(0);
+    assert.equal(result.started, true);
+    assert.equal(result.status, 'RUNNING');
+    assert.equal(result.externalIp, '203.0.113.10');
+    assert.equal(clients.instances.start.mock.callCount(), 1);
+    assert.equal(clients.operations.wait.mock.callCount(), 1);
+  });
+
+  it('ensureStarted is a no-op when already running', async () => {
+    const clients = makeClients({ status: 'RUNNING', natIP: '203.0.113.9' });
+    const gce = new GceController(
+      { projectId: 'p', zone: 'z', instance: 'main' },
+      clients
+    );
+    const result = await gce.ensureStarted(0);
+    assert.equal(result.started, false);
+    assert.equal(result.externalIp, '203.0.113.9');
+    assert.equal(clients.instances.start.mock.callCount(), 0);
+  });
+
+  it('respects start cooldown', async () => {
+    const clients = makeClients({ status: 'TERMINATED' });
+    const gce = new GceController(
+      { projectId: 'p', zone: 'z', instance: 'main' },
+      clients
+    );
+    gce._lastStartAttempt = Date.now();
+    const result = await gce.ensureStarted(60_000);
+    assert.equal(result.skipped, 'cooldown');
+    assert.equal(clients.instances.start.mock.callCount(), 0);
+  });
+
+  it('ensureStopped stops a running VM', async () => {
+    const clients = makeClients({ status: 'RUNNING', natIP: '203.0.113.9' });
+    const gce = new GceController(
+      { projectId: 'p', zone: 'z', instance: 'main' },
+      clients
+    );
+    const result = await gce.ensureStopped();
+    assert.equal(result.stopped, true);
+    assert.equal(result.status, 'TERMINATED');
+    assert.equal(clients.instances.stop.mock.callCount(), 1);
+  });
+});

--- a/wake-proxy/tests/unit.test.js
+++ b/wake-proxy/tests/unit.test.js
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadConfig } from '../src/config.js';
+import { renderStartingPage } from '../src/starting-page.js';
+import { wantsHtml } from '../src/proxy.js';
+import { waitForHealthy } from '../src/gce.js';
+
+describe('loadConfig', () => {
+  it('uses defaults', () => {
+    const cfg = loadConfig({});
+    assert.equal(cfg.projectId, 'photogroup-215600');
+    assert.equal(cfg.zone, 'asia-east2-a');
+    assert.equal(cfg.instance, 'main');
+    assert.equal(cfg.originScheme, 'http');
+    assert.equal(cfg.healthPath, '/api/__rtcConfig__');
+  });
+
+  it('reads overrides from env', () => {
+    const cfg = loadConfig({
+      GCP_PROJECT: 'demo',
+      GCE_ZONE: 'us-west1-a',
+      GCE_INSTANCE: 'box',
+      PORT: '9090',
+      READY_TIMEOUT_MS: '1000',
+      WAKE_STOP_SECRET: 's3cret',
+    });
+    assert.equal(cfg.projectId, 'demo');
+    assert.equal(cfg.zone, 'us-west1-a');
+    assert.equal(cfg.instance, 'box');
+    assert.equal(cfg.port, 9090);
+    assert.equal(cfg.readyTimeoutMs, 1000);
+    assert.equal(cfg.stopSecret, 's3cret');
+  });
+});
+
+describe('renderStartingPage', () => {
+  it('includes brand and escapes HTML', () => {
+    const html = renderStartingPage({ brand: '<Hack>', statusText: 'x', idleMinutes: 45 });
+    assert.match(html, /&lt;Hack&gt;/);
+    assert.doesNotMatch(html, /<Hack>/);
+    assert.match(html, /45 minutes/);
+    assert.match(html, /__wake__\/status/);
+  });
+});
+
+describe('wantsHtml', () => {
+  it('detects document navigations', () => {
+    assert.equal(wantsHtml({ headers: { 'sec-fetch-dest': 'document', accept: '' }, url: '/' }), true);
+    assert.equal(wantsHtml({ headers: { accept: 'text/html' }, url: '/' }), true);
+    assert.equal(wantsHtml({ headers: { accept: 'application/json' }, url: '/api/rooms/' }), false);
+    assert.equal(wantsHtml({ headers: { accept: '*/*' }, url: '/api/__rtcConfig__' }), false);
+    assert.equal(wantsHtml({ headers: { accept: '*/*' }, url: '/' }), true);
+  });
+});
+
+describe('waitForHealthy', () => {
+  it('returns healthy when fetch succeeds', async () => {
+    const result = await waitForHealthy({
+      scheme: 'https',
+      ip: '1.2.3.4',
+      host: 'example.com',
+      path: '/health',
+      timeoutMs: 1000,
+      pollMs: 10,
+      fetchImpl: async () => ({ ok: true }),
+    });
+    assert.equal(result.healthy, true);
+  });
+
+  it('times out when unhealthy', async () => {
+    const result = await waitForHealthy({
+      scheme: 'https',
+      ip: '1.2.3.4',
+      host: 'example.com',
+      path: '/health',
+      timeoutMs: 50,
+      pollMs: 10,
+      fetchImpl: async () => ({ ok: false, status: 502 }),
+    });
+    assert.equal(result.healthy, false);
+  });
+});

--- a/wake-proxy/vm-idle-stop/idle-stop.sh
+++ b/wake-proxy/vm-idle-stop/idle-stop.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Auto-stop this GCE VM when nginx has been idle for IDLE_MINUTES.
+# Installed as a systemd timer by install-idle-stop.sh.
+# Uses the instance metadata service + Compute Engine REST API (no gcloud required).
+
+set -euo pipefail
+
+IDLE_MINUTES="${IDLE_MINUTES:-60}"
+ACCESS_LOG="${ACCESS_LOG:-/var/log/nginx/access.log}"
+METADATA="http://metadata.google.internal/computeMetadata/v1"
+META_HEADER="Metadata-Flavor: Google"
+
+log() { echo "[idle-stop] $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
+
+# Skip if someone is actively connected right now (optional soft check)
+if command -v ss >/dev/null 2>&1; then
+  ACTIVE=$(ss -tn state established '( sport = :443 or sport = :80 )' 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
+  if [ "${ACTIVE:-0}" -gt 0 ]; then
+    log "active TCP connections on 80/443 ($ACTIVE) — not stopping"
+    exit 0
+  fi
+fi
+
+if [ ! -f "$ACCESS_LOG" ]; then
+  log "access log missing ($ACCESS_LOG) — treating as idle"
+  LAST_ACTIVITY_EPOCH=0
+else
+  # Prefer mtime of access log (updated on each request)
+  LAST_ACTIVITY_EPOCH=$(stat -c %Y "$ACCESS_LOG" 2>/dev/null || echo 0)
+fi
+
+NOW_EPOCH=$(date +%s)
+IDLE_SECONDS=$((IDLE_MINUTES * 60))
+AGE=$((NOW_EPOCH - LAST_ACTIVITY_EPOCH))
+
+if [ "$AGE" -lt "$IDLE_SECONDS" ]; then
+  log "last nginx activity ${AGE}s ago (< ${IDLE_SECONDS}s) — not stopping"
+  exit 0
+fi
+
+log "idle for ${AGE}s (>= ${IDLE_SECONDS}s) — stopping instance"
+
+PROJECT=$(curl -fsS -H "$META_HEADER" "$METADATA/project/project-id")
+ZONE_PATH=$(curl -fsS -H "$META_HEADER" "$METADATA/instance/zone")
+ZONE="${ZONE_PATH##*/}"
+INSTANCE=$(curl -fsS -H "$META_HEADER" "$METADATA/instance/name")
+TOKEN=$(curl -fsS -H "$META_HEADER" "$METADATA/instance/service-accounts/default/token" | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+if [ -z "$TOKEN" ] || [ -z "$PROJECT" ] || [ -z "$ZONE" ] || [ -z "$INSTANCE" ]; then
+  log "ERROR: failed to read metadata (project/zone/instance/token)"
+  exit 1
+fi
+
+HTTP_CODE=$(curl -sS -o /tmp/idle-stop-response.json -w '%{http_code}' \
+  -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://compute.googleapis.com/compute/v1/projects/${PROJECT}/zones/${ZONE}/instances/${INSTANCE}/stop")
+
+log "stop API HTTP $HTTP_CODE — $(head -c 200 /tmp/idle-stop-response.json 2>/dev/null || true)"
+if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+  exit 0
+fi
+exit 1

--- a/wake-proxy/vm-idle-stop/install-idle-stop.sh
+++ b/wake-proxy/vm-idle-stop/install-idle-stop.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Install idle-stop.sh as a systemd timer on the PhotoGroup VM.
+# Run from the repo root: ./wake-proxy/vm-idle-stop/install-idle-stop.sh
+# Or invoke via deploy-wake-proxy.sh / deploy-docker.sh.
+
+set -euo pipefail
+
+ZONE="${ZONE:-asia-east2-a}"
+INSTANCE="${INSTANCE:-main}"
+PROJECT="${PROJECT:-photogroup-215600}"
+IDLE_MINUTES="${IDLE_MINUTES:-60}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Installing VM idle-stop (idle after ${IDLE_MINUTES} minutes)..."
+echo "Project: $PROJECT  Instance: $INSTANCE  Zone: $ZONE"
+
+if ! gcloud compute instances describe "$INSTANCE" --project "$PROJECT" --zone "$ZONE" &>/dev/null; then
+  echo "ERROR: VM '$INSTANCE' not found"
+  exit 1
+fi
+
+gcloud compute scp "$SCRIPT_DIR/idle-stop.sh" "$INSTANCE:/tmp/idle-stop.sh" \
+  --project "$PROJECT" --zone "$ZONE" 2>&1 | grep -v "ssh metadata" || true
+
+gcloud compute ssh "$INSTANCE" --project "$PROJECT" --zone "$ZONE" --command "
+  set -e
+  sudo mkdir -p /opt/photogroup
+  sudo mv /tmp/idle-stop.sh /opt/photogroup/idle-stop.sh
+  sudo chmod 755 /opt/photogroup/idle-stop.sh
+
+  sudo tee /etc/systemd/system/photogroup-idle-stop.service > /dev/null <<EOF
+[Unit]
+Description=Stop PhotoGroup VM when nginx has been idle
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=IDLE_MINUTES=${IDLE_MINUTES}
+Environment=ACCESS_LOG=/var/log/nginx/access.log
+ExecStart=/opt/photogroup/idle-stop.sh
+EOF
+
+  sudo tee /etc/systemd/system/photogroup-idle-stop.timer > /dev/null <<EOF
+[Unit]
+Description=Check PhotoGroup VM idle every 10 minutes
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=10min
+AccuracySec=1min
+Unit=photogroup-idle-stop.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now photogroup-idle-stop.timer
+  sudo systemctl status photogroup-idle-stop.timer --no-pager || true
+  echo 'Idle-stop timer installed.'
+" 2>&1 | grep -v "ssh metadata" || true
+
+echo ""
+echo "NOTE: The VM service account needs roles/compute.instanceAdmin.v1 (or"
+echo "compute.instances.stop) on this instance. Grant if stop calls fail:"
+echo "  gcloud compute instances describe $INSTANCE --project $PROJECT --zone $ZONE --format='get(serviceAccounts[0].email)'"
+echo "  gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:SA_EMAIL --role=roles/compute.instanceAdmin.v1"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the recommended cost-saving architecture for low-traffic Asia hosting:

- **Cloud Run wake proxy** (`wake-proxy/`) starts the `asia-east2` GCE VM on demand, shows a cold-start page (~1–2 min), then reverse-proxies HTTP + WebSocket traffic to nginx
- **VM idle-stop timer** stops the instance after ~60 minutes without nginx traffic
- **Ephemeral IP** (no reserved static IP) so idle cost is ~$0/month
- DNS moves to Cloud Run; public HTTPS terminates there; wake proxy talks HTTP `:80` with `X-Wake-Proxy: 1`

## New / updated

| Path | Purpose |
|------|---------|
| `wake-proxy/` | Cloud Run service + unit tests |
| `deploy-wake-proxy.sh` | Build/push/deploy + IAM + idle-stop install |
| `release-static-ip.sh` | Detach/delete legacy `main-ip` after DNS cutover |
| `server/config/photogroup.network` | Allow wake-proxy HTTP origin |
| `create-vm.sh` | Default ephemeral IP (`USE_STATIC_IP=1` for legacy) |
| CI `deploy.yml` / `test.yml` | Start stopped VM before deploy; deploy wake proxy; test wake-proxy |

## Cutover steps (after merge)

1. Deploy nginx + app (existing), then `./deploy-wake-proxy.sh`
2. Point DNS at Cloud Run (domain mapping or Cloudflare CNAME → `*.run.app`)
3. `./release-static-ip.sh`
4. Optional: set GitHub secret `WAKE_STOP_SECRET` for `/__wake__/stop`

See `DEPLOYMENT.md` → **Cost-saving architecture**.

## Tests

- Wake proxy: 10/10 passed
- Server unit: 98 passed
- Server API: 28 passed
- Server integration: 12 passed
- UI unit: 72 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

