### PR TITLE
Fix wake-proxy deploy: GCP IAM setup for GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,8 +97,11 @@ jobs:
 
       - name: Deploy wake proxy to Cloud Run
         run: |
-          chmod +x deploy-wake-proxy.sh wake-proxy/vm-idle-stop/install-idle-stop.sh
-          # App deploy already ran; refresh Cloud Run image + idle-stop timer
+          chmod +x deploy-wake-proxy.sh setup-wake-proxy-iam.sh wake-proxy/vm-idle-stop/install-idle-stop.sh
+          # App deploy already ran; refresh Cloud Run image + idle-stop timer.
+          # If this fails with Permission denied on services.enable / run.admin /
+          # storage, a project Owner must run ./setup-wake-proxy-iam.sh once, then
+          # re-run this workflow. See DEPLOYMENT.md.
           ./deploy-wake-proxy.sh
         timeout-minutes: 20
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,9 +154,11 @@ This project requires Node.js >= 24.0.0. The VM update script handles installing
 No database, Redis, or Docker needed for development. All state is in-memory. Twilio credentials are optional (only needed for TURN relay NAT traversal; app falls back to Google STUN servers without them).
 
 ### Production wake / cost control
+- One-time IAM (Owner): `./setup-wake-proxy-iam.sh`
 - Deploy wake proxy: `./deploy-wake-proxy.sh`
 - Release static IP after DNS cutover: `./release-static-ip.sh`
 - Idle stop runs on the VM via `photogroup-idle-stop.timer` (default 60 minutes)
+- Failed deploy example (missing IAM): https://github.com/acuhlmann/photogroup/actions/runs/29183337976
 
 ### Pushing changes
 Always push to `main`. Before pushing:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -34,11 +34,19 @@ Public HTTPS is terminated at **Cloud Run** (domain mapping / Cloudflare). The w
 
 ### Deploy / migrate to wake proxy
 
+0. **One-time IAM (project Owner)** — required before CI or the limited GitHub Actions SA can deploy Cloud Run:
+   ```bash
+   gcloud auth login
+   ./setup-wake-proxy-iam.sh
+   ```
+   This enables Cloud Run / Artifact Registry APIs and grants `github-actions-deploy@…` the roles it needs (`run.admin`, `storage.admin`, `iam.serviceAccountAdmin`, etc.). Without this step, deploy fails with `Permission denied to enable service […]` (example: [failed run](https://github.com/acuhlmann/photogroup/actions/runs/29183337976)).
+
 1. Ensure the VM, nginx, Docker apps, and SSL on the VM still work (origin HTTPS).
 2. Deploy the wake proxy:
    ```bash
    ./deploy-wake-proxy.sh
    ```
+   Or re-run **Actions → Deploy to GCP VM → Run workflow** after IAM setup.
 3. Point DNS at Cloud Run (replace the old A record that targeted the VM):
    ```bash
    # If domain mappings are available in asia-east2:

--- a/deploy-wake-proxy.sh
+++ b/deploy-wake-proxy.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Deploy the PhotoGroup wake proxy to Cloud Run and (optionally) install VM idle-stop.
 #
-# Prerequisites:
-#   - gcloud authenticated with permission to deploy Cloud Run + manage IAM
-#   - Docker available locally (or Cloud Build)
+# Prerequisites (one-time, as project Owner):
+#   ./setup-wake-proxy-iam.sh
 #
-# Usage:
+# Then:
 #   ./deploy-wake-proxy.sh
 #   WAKE_STOP_SECRET=... IDLE_MINUTES=60 ./deploy-wake-proxy.sh
 #   SKIP_IDLE_STOP=1 ./deploy-wake-proxy.sh   # deploy Cloud Run only
@@ -29,29 +28,59 @@ echo "Project:  $PROJECT"
 echo "Region:   $REGION"
 echo "Service:  $SERVICE"
 echo "VM:       $INSTANCE ($ZONE)"
+echo "Account:  $(gcloud config get-value account 2>/dev/null || echo unknown)"
 echo ""
 
 gcloud config set project "$PROJECT" >/dev/null
 
-# Enable required APIs (idempotent)
-gcloud services enable \
+# Prefer soft-enable: GitHub Actions SA usually cannot enable APIs (needs
+# serviceusage.serviceUsageAdmin). Owner should run ./setup-wake-proxy-iam.sh once.
+echo "Checking required APIs (enable is best-effort)..."
+ENABLE_OUT=$(gcloud services enable \
   run.googleapis.com \
   compute.googleapis.com \
   artifactregistry.googleapis.com \
   cloudbuild.googleapis.com \
-  --project "$PROJECT" >/dev/null
+  --project "$PROJECT" 2>&1) && ENABLE_OK=1 || ENABLE_OK=0
+if [ "$ENABLE_OK" != "1" ]; then
+  echo "$ENABLE_OUT" | sed 's/^/  /'
+  echo ""
+  echo "WARNING: Could not enable APIs (often missing serviceusage permission)."
+  echo "         Continuing — APIs may already be enabled."
+  echo "         If deploy fails next, run as project Owner:"
+  echo "           ./setup-wake-proxy-iam.sh"
+  echo ""
+fi
+
+# Verify critical APIs are actually usable
+for API in run.googleapis.com compute.googleapis.com; do
+  STATE=$(gcloud services list --enabled --project "$PROJECT" \
+    --filter="config.name:$API" --format='value(config.name)' 2>/dev/null || true)
+  if [ -z "$STATE" ]; then
+    echo "ERROR: Required API '$API' is not enabled on project $PROJECT."
+    echo "Run as Owner: ./setup-wake-proxy-iam.sh"
+    echo "Or: gcloud services enable $API --project $PROJECT"
+    exit 1
+  fi
+done
+echo "Required APIs are enabled."
 
 # Service account for the wake proxy
 SA_NAME="photogroup-wake"
 SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
 if ! gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT" &>/dev/null; then
   echo "Creating service account $SA_EMAIL..."
-  gcloud iam service-accounts create "$SA_NAME" \
-    --project "$PROJECT" \
-    --display-name "PhotoGroup wake proxy"
+  if ! gcloud iam service-accounts create "$SA_NAME" \
+      --project "$PROJECT" \
+      --display-name "PhotoGroup wake proxy"; then
+    echo "ERROR: Failed to create $SA_EMAIL"
+    echo "The deploy identity needs roles/iam.serviceAccountAdmin, or run:"
+    echo "  ./setup-wake-proxy-iam.sh"
+    exit 1
+  fi
 fi
 
-# Grant start/stop/get on Compute Engine
+# Grant start/stop/get on Compute Engine (best-effort; setup script is authoritative)
 echo "Ensuring IAM roles on wake service account..."
 for ROLE in roles/compute.instanceAdmin.v1 roles/iam.serviceAccountUser; do
   gcloud projects add-iam-policy-binding "$PROJECT" \
@@ -78,7 +107,12 @@ echo "Building and pushing image $IMAGE ..."
 export DOCKER_BUILDKIT=1
 docker build -t "$IMAGE" "$ROOT/wake-proxy"
 gcloud auth configure-docker --quiet
-docker push "$IMAGE"
+if ! docker push "$IMAGE"; then
+  echo "ERROR: docker push failed."
+  echo "GitHub Actions SA needs roles/storage.admin (GCR) or Artifact Registry writer."
+  echo "Fix with: ./setup-wake-proxy-iam.sh"
+  exit 1
+fi
 
 ENV_VARS="GCP_PROJECT=${PROJECT},GCE_ZONE=${ZONE},GCE_INSTANCE=${INSTANCE},ORIGIN_SCHEME=http,HEALTH_PATH=/api/__rtcConfig__,IDLE_MINUTES=${IDLE_MINUTES}"
 if [ -n "${WAKE_STOP_SECRET:-}" ]; then
@@ -86,7 +120,7 @@ if [ -n "${WAKE_STOP_SECRET:-}" ]; then
 fi
 
 echo "Deploying Cloud Run service $SERVICE ..."
-gcloud run deploy "$SERVICE" \
+if ! gcloud run deploy "$SERVICE" \
   --project "$PROJECT" \
   --region "$REGION" \
   --image "$IMAGE" \
@@ -101,7 +135,12 @@ gcloud run deploy "$SERVICE" \
   --concurrency 80 \
   --session-affinity \
   --service-account "$SA_EMAIL" \
-  --set-env-vars "$ENV_VARS"
+  --set-env-vars "$ENV_VARS"; then
+  echo "ERROR: Cloud Run deploy failed."
+  echo "GitHub Actions SA needs roles/run.admin and permission to act as $SA_EMAIL."
+  echo "Fix with: ./setup-wake-proxy-iam.sh"
+  exit 1
+fi
 
 SERVICE_URL=$(gcloud run services describe "$SERVICE" \
   --project "$PROJECT" --region "$REGION" \

--- a/setup-wake-proxy-iam.sh
+++ b/setup-wake-proxy-iam.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# One-time IAM + API setup for the PhotoGroup wake proxy.
+#
+# Run this as a project Owner / Editor (your user account), NOT as the limited
+# GitHub Actions deploy SA. After this succeeds, CI can deploy with
+# ./deploy-wake-proxy.sh.
+#
+# Usage:
+#   gcloud auth login
+#   ./setup-wake-proxy-iam.sh
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-photogroup-215600}"
+REGION="${REGION:-asia-east2}"
+ZONE="${ZONE:-asia-east2-a}"
+INSTANCE="${INSTANCE:-main}"
+GHA_SA="${GHA_SA:-github-actions-deploy@${PROJECT}.iam.gserviceaccount.com}"
+WAKE_SA_NAME="photogroup-wake"
+WAKE_SA="${WAKE_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+echo "=========================================="
+echo "Wake proxy IAM / API one-time setup"
+echo "=========================================="
+echo "Project:     $PROJECT"
+echo "GitHub SA:   $GHA_SA"
+echo "Wake SA:     $WAKE_SA"
+echo ""
+echo "Active account: $(gcloud config get-value account 2>/dev/null || true)"
+echo ""
+
+gcloud config set project "$PROJECT" >/dev/null
+
+echo "1) Enabling required APIs..."
+gcloud services enable \
+  run.googleapis.com \
+  compute.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com \
+  iam.googleapis.com \
+  --project "$PROJECT"
+echo "   APIs enabled."
+
+echo "2) Creating wake proxy runtime service account (if missing)..."
+if gcloud iam service-accounts describe "$WAKE_SA" --project "$PROJECT" &>/dev/null; then
+  echo "   Already exists: $WAKE_SA"
+else
+  gcloud iam service-accounts create "$WAKE_SA_NAME" \
+    --project "$PROJECT" \
+    --display-name "PhotoGroup wake proxy"
+  echo "   Created: $WAKE_SA"
+fi
+
+echo "3) Granting roles to wake runtime SA (start/stop VM)..."
+for ROLE in roles/compute.instanceAdmin.v1 roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${WAKE_SA}" \
+    --role="$ROLE" \
+    --condition=None \
+    >/dev/null
+  echo "   $WAKE_SA ← $ROLE"
+done
+
+echo "4) Granting roles to GitHub Actions deploy SA (needed for CI wake-proxy deploy)..."
+for ROLE in \
+  roles/run.admin \
+  roles/iam.serviceAccountAdmin \
+  roles/iam.serviceAccountUser \
+  roles/storage.admin \
+  roles/artifactregistry.writer \
+  roles/serviceusage.serviceUsageConsumer
+do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${GHA_SA}" \
+    --role="$ROLE" \
+    --condition=None \
+    >/dev/null
+  echo "   $GHA_SA ← $ROLE"
+done
+
+# Allow GHA SA to act as the wake runtime SA when deploying Cloud Run
+gcloud iam service-accounts add-iam-policy-binding "$WAKE_SA" \
+  --project "$PROJECT" \
+  --member="serviceAccount:${GHA_SA}" \
+  --role="roles/iam.serviceAccountUser" \
+  >/dev/null
+echo "   $GHA_SA can act as $WAKE_SA"
+
+echo "5) Ensuring VM SA can stop itself (idle-stop)..."
+VM_SA=$(gcloud compute instances describe "$INSTANCE" \
+  --project "$PROJECT" --zone "$ZONE" \
+  --format='get(serviceAccounts[0].email)' 2>/dev/null || true)
+if [ -n "${VM_SA:-}" ]; then
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${VM_SA}" \
+    --role="roles/compute.instanceAdmin.v1" \
+    --condition=None \
+    >/dev/null
+  echo "   $VM_SA ← roles/compute.instanceAdmin.v1"
+else
+  echo "   WARNING: could not read VM service account (is the instance running?)"
+fi
+
+echo ""
+echo "=========================================="
+echo "Setup complete"
+echo "=========================================="
+echo "Next:"
+echo "  1. Re-run the failed GitHub Actions deploy, or:"
+echo "       ./deploy-wake-proxy.sh"
+echo "  2. Failed deploy that triggered this fix:"
+echo "       https://github.com/acuhlmann/photogroup/actions/runs/29183337976"
+echo ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging #108, [Deploy to GCP VM failed](https://github.com/acuhlmann/photogroup/actions/runs/29183337976) on **Deploy wake proxy to Cloud Run**:

```text
github-actions-deploy@photogroup-215600.iam.gserviceaccount.com
does not have permission to access projects instance [photogroup-215600]:
Permission denied to enable service [run.googleapis.com]
(and artifactregistry / cloudbuild / compute)
```

Nginx + Docker deploy steps succeeded; only the new Cloud Run wake-proxy step failed.

## Fix

1. **`deploy-wake-proxy.sh`** — API `enable` is best-effort (CI SA usually cannot enable APIs). Clearer errors that point at the setup script.
2. **`setup-wake-proxy-iam.sh`** — one-time script for a **project Owner** to:
   - enable Run / Compute / Artifact Registry / Cloud Build APIs
   - create `photogroup-wake@…` runtime SA
   - grant CI SA: `run.admin`, `storage.admin`, `iam.serviceAccountAdmin`, `artifactregistry.writer`, etc.
   - allow VM SA to stop itself for idle-stop

## What you need to do (Owner, once)

```bash
gcloud auth login
gcloud config set project photogroup-215600
# from repo root on this branch / after merge:
./setup-wake-proxy-iam.sh
```

Then re-run deploy:

- GitHub → Actions → **Deploy to GCP VM** → **Run workflow**, or
- `./deploy-wake-proxy.sh` locally

## Links

- Failed run: https://github.com/acuhlmann/photogroup/actions/runs/29183337976
- Original PR: https://github.com/acuhlmann/photogroup/pull/108

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

