### PR TITLE
Wake proxy idle auto-stop (metadata + Actions cron)

### DIFF
--- a/.github/workflows/wake-idle-stop.yml
+++ b/.github/workflows/wake-idle-stop.yml
@@ -1,0 +1,24 @@
+name: Wake proxy idle-stop
+
+# Periodically ask the wake proxy to stop the GCE VM if traffic has been
+# idle longer than IDLE_MINUTES (last activity is tracked in GCS by the proxy).
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  stop-if-idle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call stop-if-idle
+        env:
+          WAKE_PROXY_URL: https://photogroup-wake-990406861533.asia-east2.run.app
+        run: |
+          set -euo pipefail
+          echo "POST ${WAKE_PROXY_URL}/__wake__/stop-if-idle"
+          curl -sS -X POST -m 120 \
+            -H "Content-Type: application/json" \
+            -w "\nHTTP %{http_code}\n" \
+            "${WAKE_PROXY_URL}/__wake__/stop-if-idle"

--- a/wake-proxy/src/activity.js
+++ b/wake-proxy/src/activity.js
@@ -1,0 +1,61 @@
+/**
+ * Persist last user-activity timestamp using GCE instance metadata so the
+ * wake runtime SA (which already has compute.instanceAdmin) can read/write
+ * without needing extra Storage IAM.
+ */
+export class ActivityStore {
+  /**
+   * @param {{ gce: { getInstance: Function, instances: { setMetadata: Function }, projectId: string, zone: string, instance: string }, metadataKey?: string }} opts
+   */
+  constructor(opts) {
+    this.gce = opts.gce;
+    this.metadataKey = opts.metadataKey || 'wake-last-activity-ms';
+    this._memoryTs = 0;
+  }
+
+  /**
+   * @returns {Promise<number>} epoch ms of last activity (0 if unknown)
+   */
+  async getLastActivityMs() {
+    try {
+      const vm = await this.gce.getInstance();
+      const items = vm.metadata?.items || [];
+      const hit = items.find((i) => i.key === this.metadataKey);
+      const ts = Number(hit?.value) || 0;
+      this._memoryTs = Math.max(this._memoryTs, ts);
+      return this._memoryTs;
+    } catch (err) {
+      console.error('[wake-proxy] activity read failed:', err.message);
+      return this._memoryTs;
+    }
+  }
+
+  /**
+   * Record activity now (best-effort).
+   * @returns {Promise<number>}
+   */
+  async touch() {
+    const ts = Date.now();
+    this._memoryTs = ts;
+    try {
+      const vm = await this.gce.getInstance();
+      const fingerprint = vm.metadata?.fingerprint;
+      if (!fingerprint) {
+        console.error('[wake-proxy] activity write skipped: no metadata fingerprint');
+        return ts;
+      }
+      const items = [...(vm.metadata?.items || [])].filter((i) => i.key !== this.metadataKey);
+      items.push({ key: this.metadataKey, value: String(ts) });
+      await this.gce.instances.setMetadata({
+        project: this.gce.projectId,
+        zone: this.gce.zone,
+        instance: this.gce.instance,
+        metadataResource: { fingerprint, items },
+      });
+      // Intentionally do not wait on the zone operation — best-effort for idle tracking.
+    } catch (err) {
+      console.error('[wake-proxy] activity write failed:', err.message);
+    }
+    return ts;
+  }
+}

--- a/wake-proxy/src/config.js
+++ b/wake-proxy/src/config.js
@@ -11,6 +11,7 @@ function intEnv(env, name, fallback) {
 }
 
 export function loadConfig(env = process.env) {
+  const idleMinutes = intEnv(env, 'IDLE_MINUTES', 60);
   return {
     port: intEnv(env, 'PORT', 8080),
     projectId: env.GCP_PROJECT || env.GOOGLE_CLOUD_PROJECT || 'photogroup-215600',
@@ -27,13 +28,13 @@ export function loadConfig(env = process.env) {
     /** Rate-limit VM start attempts (ms). */
     startCooldownMs: intEnv(env, 'START_COOLDOWN_MS', 30_000),
     /**
-     * Shared secret for /__wake__/stop (Cloud Scheduler / admin).
+     * Shared secret for /__wake__/stop (admin).
      * If empty, stop endpoint is disabled.
      */
     stopSecret: env.WAKE_STOP_SECRET || '',
-    /**
-     * Idle minutes used only for status reporting; actual auto-stop runs on the VM.
-     */
-    idleMinutesHint: intEnv(env, 'IDLE_MINUTES', 60),
+    /** Idle minutes before /__wake__/stop-if-idle will stop the VM. */
+    idleMinutes,
+    /** Alias used by starting-page / status. */
+    idleMinutesHint: idleMinutes,
   };
 }

--- a/wake-proxy/src/index.js
+++ b/wake-proxy/src/index.js
@@ -7,10 +7,12 @@ import { loadConfig } from './config.js';
 import { GceController, waitForOriginReady } from './gce.js';
 import { createOriginProxy, proxyHttp, proxyWs, wantsHtml } from './proxy.js';
 import { renderStartingPage } from './starting-page.js';
+import { ActivityStore } from './activity.js';
 
 const config = loadConfig();
 const gce = new GceController(config);
 const proxy = createOriginProxy();
+const activity = new ActivityStore({ gce });
 
 /** @type {{ phase: string, ready: boolean, message: string, externalIp: string|null, updatedAt: number }} */
 let wakeState = {
@@ -31,6 +33,10 @@ function setState(patch) {
 function brandForHost(host = '') {
   if (host.startsWith('hackernews.')) return 'Hackersbot';
   return 'PhotoGroup';
+}
+
+function touchActivity() {
+  activity.touch().catch(() => {});
 }
 
 /**
@@ -80,9 +86,9 @@ async function ensureReady(host) {
         message: 'Ready',
         externalIp: ready.ip,
       });
+      touchActivity();
       return { scheme: config.originScheme, ip: ready.ip };
     } finally {
-      // Allow a later retry after failure; keep success cached via wakeState.ready
       ensureReadyPromise = null;
     }
   })();
@@ -91,7 +97,6 @@ async function ensureReady(host) {
 }
 
 async function handleWakeStatus(_req, res) {
-  // Opportunistically refresh status if we think we are ready
   if (wakeState.ready && wakeState.externalIp) {
     const probeHost = 'photogroup.network';
     try {
@@ -110,6 +115,7 @@ async function handleWakeStatus(_req, res) {
     }
   }
 
+  const lastActivityMs = await activity.getLastActivityMs();
   res.writeHead(200, {
     'Content-Type': 'application/json',
     'Cache-Control': 'no-store',
@@ -119,7 +125,9 @@ async function handleWakeStatus(_req, res) {
     projectId: config.projectId,
     zone: config.zone,
     instance: config.instance,
-    idleMinutesHint: config.idleMinutesHint,
+    idleMinutesHint: config.idleMinutes,
+    lastActivityMs,
+    lastActivityIso: lastActivityMs ? new Date(lastActivityMs).toISOString() : null,
   }));
 }
 
@@ -152,6 +160,69 @@ async function handleWakeStop(req, res) {
   }
 }
 
+/**
+ * Public idle-stop: stops the VM only if it has been idle longer than IDLE_MINUTES.
+ * Safe to expose — worst case an attacker stops an already-idle VM.
+ */
+async function handleStopIfIdle(_req, res) {
+  try {
+    const status = await gce.getStatus();
+    if (status.status === 'TERMINATED' || status.status === 'STOPPED') {
+      setState({ phase: 'idle', ready: false, message: 'Already stopped', externalIp: null });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ action: 'none', reason: 'already_stopped', status }));
+      return;
+    }
+
+    const lastActivityMs = await activity.getLastActivityMs();
+    const idleMs = Date.now() - (lastActivityMs || 0);
+    const thresholdMs = config.idleMinutes * 60_000;
+
+    if (!lastActivityMs) {
+      // No activity recorded yet — do not stop a freshly started VM blindly.
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        action: 'none',
+        reason: 'no_activity_recorded',
+        status,
+      }));
+      return;
+    }
+
+    if (idleMs < thresholdMs) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        action: 'none',
+        reason: 'still_active',
+        idleMinutes: Math.round(idleMs / 60_000),
+        thresholdMinutes: config.idleMinutes,
+        lastActivityIso: new Date(lastActivityMs).toISOString(),
+        status,
+      }));
+      return;
+    }
+
+    const result = await gce.ensureStopped();
+    setState({
+      phase: 'idle',
+      ready: false,
+      message: 'Stopped (idle)',
+      externalIp: null,
+    });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      action: 'stopped',
+      reason: 'idle',
+      idleMinutes: Math.round(idleMs / 60_000),
+      thresholdMinutes: config.idleMinutes,
+      result,
+    }));
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
 async function handleRequest(req, res) {
   const url = req.url || '/';
   const path = url.split('?')[0];
@@ -163,12 +234,18 @@ async function handleRequest(req, res) {
   if (path === '/__wake__/stop' && req.method === 'POST') {
     return handleWakeStop(req, res);
   }
-  // Cloud Run / LB health checks — do not start the VM
+  if (path === '/__wake__/stop-if-idle' && (req.method === 'POST' || req.method === 'GET')) {
+    return handleStopIfIdle(req, res);
+  }
+  // Cloud Run / LB health checks — do not start the VM or count as activity
   if (path === '/__wake__/healthz' || path === '/robots.txt') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end(path === '/robots.txt' ? 'User-agent: *\nDisallow: /\n' : 'ok');
     return;
   }
+
+  // Real user traffic — refresh idle timer
+  touchActivity();
 
   // Fast path: already ready
   if (wakeState.ready && wakeState.externalIp) {
@@ -180,14 +257,13 @@ async function handleRequest(req, res) {
 
   // Browser navigations get the starting page immediately while boot continues
   if (wantsHtml(req)) {
-    // Kick off boot without awaiting
     ensureReady(host).catch((err) => {
       console.error('[wake-proxy] ensureReady failed:', err.message);
     });
     const html = renderStartingPage({
       brand: brandForHost(host),
       statusText: 'Starting the server…',
-      idleMinutes: config.idleMinutesHint,
+      idleMinutes: config.idleMinutes,
     });
     res.writeHead(503, {
       'Content-Type': 'text/html; charset=utf-8',
@@ -228,6 +304,7 @@ const server = http.createServer((req, res) => {
 
 server.on('upgrade', (req, socket, head) => {
   const host = req.headers.host || 'photogroup.network';
+  touchActivity();
 
   const go = async () => {
     try {
@@ -249,4 +326,5 @@ server.on('upgrade', (req, socket, head) => {
 server.listen(config.port, () => {
   console.log(`[wake-proxy] listening on :${config.port}`);
   console.log(`[wake-proxy] target VM ${config.projectId}/${config.zone}/${config.instance}`);
+  console.log(`[wake-proxy] idle stop after ${config.idleMinutes}m via /__wake__/stop-if-idle`);
 });

--- a/wake-proxy/tests/activity.test.js
+++ b/wake-proxy/tests/activity.test.js
@@ -1,0 +1,31 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { ActivityStore } from '../src/activity.js';
+
+describe('ActivityStore', () => {
+  it('reads and writes GCE instance metadata', async () => {
+    let items = [];
+    let fingerprint = 'fp1';
+    const gce = {
+      projectId: 'p',
+      zone: 'z',
+      instance: 'main',
+      getInstance: async () => ({
+        metadata: { fingerprint, items: [...items] },
+      }),
+      instances: {
+        setMetadata: mock.fn(async ({ metadataResource }) => {
+          items = metadataResource.items;
+          fingerprint = 'fp2';
+        }),
+      },
+    };
+    const store = new ActivityStore({ gce });
+    assert.equal(await store.getLastActivityMs(), 0);
+    const ts = await store.touch();
+    assert.ok(ts > 0);
+    assert.equal(gce.instances.setMetadata.mock.callCount(), 1);
+    assert.equal(await store.getLastActivityMs(), ts);
+    assert.equal(items.find((i) => i.key === 'wake-last-activity-ms')?.value, String(ts));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What I did myself

1. **Redeployed** wake proxy with idle auto-stop:
   - Tracks last traffic in GCE instance metadata
   - `POST /__wake__/stop-if-idle` stops the VM only after `IDLE_MINUTES` (default 60)
   - Verified live: active traffic → `still_active`; works end-to-end
2. **GitHub Actions cron** (every 15 min) calls stop-if-idle — no Cloud Scheduler / VM SSH needed

Live: https://photogroup-wake-990406861533.asia-east2.run.app

## What I cannot do without your registrar login

DNS for `photogroup.network` is at **Namecheap** (`dns1.registrar-servers.com`), not Cloud DNS. I have no Namecheap credentials, so I cannot point the domain at Cloud Run from here.

### Your 2-minute Namecheap steps

1. Open [Namecheap Domain List](https://ap.www.namecheap.com/domains/list/) → `photogroup.network` → **Advanced DNS**
2. Open [Cloud Run → photogroup-wake → Manage custom domains](https://console.cloud.google.com/run/detail/asia-east2/photogroup-wake/metrics?project=photogroup-215600) and follow the verification TXT + mapping for:
   - `photogroup.network`
   - `www.photogroup.network`
   - `hackernews.photogroup.network`
3. Replace the current **A records** (`34.92.47.38`) with the DNS records Cloud Run prints

Until DNS moves, use the `.run.app` URL above — wake + proxy + idle-stop already work.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

