### PR TITLE
Move wake proxy to asia-southeast1 for custom domain mappings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 20
         env:
           ZONE: asia-east2-a
-          REGION: asia-east2
+          REGION: asia-southeast1
           INSTANCE: main
           PROJECT: photogroup-215600
           IDLE_MINUTES: 60

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,11 +16,13 @@ Recommended production shape for low-traffic Asia hosting:
 
 ```
 DNS (photogroup.network, www, hackernews)
-  → Cloud Run wake proxy (asia-east2, min instances 0)
-      → starts GCE e2-micro on demand
-      → HTTPS reverse-proxy to nginx on the VM
+  → Cloud Run wake proxy (asia-southeast1, min instances 0)
+      → starts GCE e2-micro on demand (asia-east2-a)
+      → HTTP reverse-proxy to nginx on the VM
 VM systemd timer → stops the instance after ~60 minutes of nginx idle
 ```
+
+> **Region note:** The VM stays in `asia-east2-a` (Hong Kong). Cloud Run custom-domain mappings are **not** supported in `asia-east2`, so the wake proxy is deployed in **`asia-southeast1`** (Singapore). Latency from HK visitors to Cloud Run adds ~30–50 ms; VM cold-start dominates first load.
 
 | State | Approx. monthly cost |
 |-------|----------------------|
@@ -39,15 +41,17 @@ Public HTTPS is terminated at **Cloud Run** (domain mapping / Cloudflare). The w
    ```bash
    ./deploy-wake-proxy.sh
    ```
-3. Point DNS at Cloud Run (replace the old A record that targeted the VM):
+3. Map custom domains and get DNS records (run locally with the Google account that verified the domain):
    ```bash
-   # If domain mappings are available in asia-east2:
+   chmod +x setup-domain-mappings.sh
+   ./setup-domain-mappings.sh
+   ```
+   Or manually:
+   ```bash
    gcloud beta run domain-mappings create --service photogroup-wake \
-     --domain photogroup.network --region asia-east2 --project photogroup-215600
+     --domain photogroup.network --region asia-southeast1 --project photogroup-215600
    # Repeat for www.photogroup.network and hackernews.photogroup.network
    # Then add the DNS records printed by gcloud.
-   #
-   # Alternative: Cloudflare CNAME each hostname → <service>.run.app (proxy on).
    ```
 4. Release the legacy static IP (~$3.65/mo savings when stopped):
    ```bash

--- a/deploy-wake-proxy.sh
+++ b/deploy-wake-proxy.sh
@@ -13,7 +13,8 @@
 set -euo pipefail
 
 ZONE="${ZONE:-asia-east2-a}"
-REGION="${REGION:-asia-east2}"
+# Domain mappings are not supported in asia-east2; use asia-southeast1 for Cloud Run.
+REGION="${REGION:-asia-southeast1}"
 INSTANCE="${INSTANCE:-main}"
 PROJECT="${PROJECT:-photogroup-215600}"
 SERVICE="${WAKE_SERVICE:-photogroup-wake}"
@@ -120,7 +121,10 @@ echo ""
 echo "=========================================="
 echo "Next: point DNS at Cloud Run"
 echo "=========================================="
-echo "1) Map custom domains (if supported in $REGION):"
+echo "1) Map custom domains (must use $REGION — not asia-east2):"
+echo "     ./setup-domain-mappings.sh"
+echo "   (Run on your laptop after: gcloud auth login)"
+echo "   Or manually:"
 echo "     gcloud beta run domain-mappings create --service $SERVICE --domain photogroup.network --region $REGION --project $PROJECT"
 echo "     gcloud beta run domain-mappings create --service $SERVICE --domain www.photogroup.network --region $REGION --project $PROJECT"
 echo "     gcloud beta run domain-mappings create --service $SERVICE --domain hackernews.photogroup.network --region $REGION --project $PROJECT"

--- a/setup-domain-mappings.sh
+++ b/setup-domain-mappings.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Create Cloud Run custom-domain mappings and print Namecheap DNS records.
+#
+# Run this on YOUR machine (not CI) while logged into the Google account that
+# verified photogroup.network in Search Console:
+#
+#   gcloud auth login
+#   gcloud config set project photogroup-215600
+#   ./setup-domain-mappings.sh
+#
+# Cloud Run domain mappings are NOT available in asia-east2 (Hong Kong).
+# The wake proxy runs in asia-southeast1 (Singapore) and still starts the VM
+# in asia-east2-a.
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-photogroup-215600}"
+REGION="${REGION:-asia-southeast1}"
+SERVICE="${WAKE_SERVICE:-photogroup-wake}"
+
+DOMAINS=(
+  photogroup.network
+  www.photogroup.network
+  hackernews.photogroup.network
+)
+
+echo "Project:  $PROJECT"
+echo "Region:   $REGION (domain mappings supported here)"
+echo "Service:  $SERVICE"
+echo ""
+
+gcloud config set project "$PROJECT" >/dev/null
+
+for domain in "${DOMAINS[@]}"; do
+  echo "=========================================="
+  echo "Domain: $domain"
+  echo "=========================================="
+  if gcloud beta run domain-mappings describe \
+    --domain "$domain" --region "$REGION" --project "$PROJECT" &>/dev/null; then
+    echo "Mapping already exists."
+  else
+    gcloud beta run domain-mappings create \
+      --service "$SERVICE" \
+      --domain "$domain" \
+      --region "$REGION" \
+      --project "$PROJECT"
+  fi
+  echo ""
+  gcloud beta run domain-mappings describe \
+    --domain "$domain" \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --format='yaml(status.resourceRecords,status.conditions)'
+  echo ""
+done
+
+cat <<'EOF'
+
+Namecheap Advanced DNS (photogroup.network)
+-------------------------------------------
+1) DELETE old A records pointing at the VM IP (34.92.47.38) for @, www, hackernews.
+2) KEEP the SPF TXT on @ unless you know you do not need it.
+3) ADD every resourceRecord printed above (exact type/host/value).
+4) Wait for DNS propagation, then:
+     curl -sS https://photogroup.network/__wake__/status
+
+Typical pattern (confirm against output above):
+  photogroup.network      → 4× A + 4× AAAA on Host @
+  www.photogroup.network  → CNAME www → ghs.googlehosted.com
+  hackernews...           → CNAME hackernews → ghs.googlehosted.com
+EOF


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Run custom-domain mappings are not supported in `asia-east2` (Hong Kong). The wake proxy is redeployed in `asia-southeast1` (Singapore); the GCE VM remains in `asia-east2-a`.

## Changes
- Default `REGION` in `deploy-wake-proxy.sh` → `asia-southeast1`
- GitHub Actions deploy workflow uses the same region
- Add `setup-domain-mappings.sh` — run locally after `gcloud auth login` with the account that verified `photogroup.network`
- Document region split in `DEPLOYMENT.md`

## Already done in GCP (manual)
- `photogroup-wake` deployed to `asia-southeast1`
- Old `asia-east2` Cloud Run service removed

## User follow-up (requires personal Google login)
```bash
gcloud auth login
gcloud config set project photogroup-215600
./setup-domain-mappings.sh
```
Then paste the printed DNS records into Namecheap Advanced DNS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ed15308-42f6-4635-9125-15a2b6448816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

